### PR TITLE
Commenting swagger-jaxrs dependency

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
+++ b/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
@@ -138,11 +138,11 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-jaxrs</artifactId>
-            <version>${swagger.jaxrs.version}</version>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>io.swagger</groupId>-->
+            <!--<artifactId>swagger-jaxrs</artifactId>-->
+            <!--<version>${swagger.jaxrs.version}</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>


### PR DESCRIPTION
## Purpose
> Commenting swagger-jaxrs dependency to avoid build failures
