### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
@@ -197,7 +197,9 @@ public class ConsentConstants {
         ERROR_CODE_PURPOSE_GROUP_REQUIRED("CM_00086", "Purpose group is required."),
         ERROR_CODE_PURPOSE_GROUP_TYPE_REQUIRED("CM_00087", "Purpose group type is required."),
         ERROR_CODE_PURPOSE_PII_CONSTRAINT_REQUIRED("CM_00088", "Purpose PII category should be specified mandatory or" +
-                                                               " not for PII category ID: %s.");
+                                                               " not for PII category ID: %s."),
+        ERROR_CODE_ROLL_BACK_CONNECTION("CM_00089", "Transaction rollback connection error occurred while creating"
+                + " database tables for Consent Management.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/util/ConsentDBInitializer.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/util/ConsentDBInitializer.java
@@ -39,6 +39,7 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMe
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_DATABASE_CONNECTION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_GET_DB_TYPE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_NO_SQL_SCRIPT;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_ROLL_BACK_CONNECTION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_RUN_SQL_QUERY;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_RUN_SQL_SCRIPT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_DB;
@@ -152,6 +153,11 @@ public class ConsentDBInitializer {
                 conn.commit();
                 log.debug("Consent tables are created successfully.");
             } catch (SQLException e) {
+                try {
+                    conn.rollback();
+                } catch (SQLException e1) {
+                    throw ConsentUtils.handleRuntimeException(ERROR_CODE_ROLL_BACK_CONNECTION, null, e1);
+                }
                 throw ConsentUtils.handleRuntimeException(ERROR_CODE_CREATE_DB_TABLES, null, e);
 
             } finally {


### PR DESCRIPTION

## Purpose
When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the carbon-consent-management repository, there are some places use the JDBC transaction but did not properly commit and rollback the transaction.

Issue: https://github.com/wso2/product-is/issues/5479