### PR TITLE
Issue due to username case sensitivity in consent management Fixed 

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
@@ -199,7 +199,11 @@ public class ConsentConstants {
         ERROR_CODE_PURPOSE_PII_CONSTRAINT_REQUIRED("CM_00088", "Purpose PII category should be specified mandatory or" +
                                                                " not for PII category ID: %s."),
         ERROR_CODE_ROLL_BACK_CONNECTION("CM_00089", "Transaction rollback connection error occurred while creating"
-                + " database tables for Consent Management.");
+                + " database tables for Consent Management."),
+        ERROR_CODE_GETTING_USER_STORE_MANAGER("CM_00089", "Error while retrieving the user store manager for the user"
+                + " name: %s."),
+
+        ERROR_CODE_GETTING_TENANT_ID("CM_00090", "Error in obtaining tenant ID from tenant domain: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImplTest.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImplTest.java
@@ -1,0 +1,318 @@
+/*
+ *
+ *   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.consent.mgt.core;
+
+import org.mockito.Mock;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.consent.mgt.core.connector.PIIController;
+import org.wso2.carbon.consent.mgt.core.connector.impl.DefaultPIIController;
+import org.wso2.carbon.consent.mgt.core.constant.ConsentConstants;
+import org.wso2.carbon.consent.mgt.core.dao.PIICategoryDAO;
+import org.wso2.carbon.consent.mgt.core.dao.PurposeCategoryDAO;
+import org.wso2.carbon.consent.mgt.core.dao.PurposeDAO;
+import org.wso2.carbon.consent.mgt.core.dao.ReceiptDAO;
+import org.wso2.carbon.consent.mgt.core.dao.impl.PIICategoryDAOImpl;
+import org.wso2.carbon.consent.mgt.core.dao.impl.PurposeCategoryDAOImpl;
+import org.wso2.carbon.consent.mgt.core.dao.impl.PurposeDAOImpl;
+import org.wso2.carbon.consent.mgt.core.dao.impl.ReceiptDAOImpl;
+import org.wso2.carbon.consent.mgt.core.internal.ConsentManagerComponentDataHolder;
+import org.wso2.carbon.consent.mgt.core.model.Address;
+import org.wso2.carbon.consent.mgt.core.model.ConsentManagerConfigurationHolder;
+import org.wso2.carbon.consent.mgt.core.model.PIICategory;
+import org.wso2.carbon.consent.mgt.core.model.PIICategoryValidity;
+import org.wso2.carbon.consent.mgt.core.model.PiiController;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptListResponse;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptPurposeInput;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptServiceInput;
+import org.wso2.carbon.consent.mgt.core.util.ConsentConfigParser;
+import org.wso2.carbon.consent.mgt.core.util.TestUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.core.util.KeyStoreManager;
+import org.wso2.carbon.user.api.AuthorizationManager;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.wso2.carbon.CarbonConstants.UI_PERMISSION_ACTION;
+import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PERMISSION_CONSENT_MGT_DELETE;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PERMISSION_CONSENT_MGT_LIST;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PERMISSION_CONSENT_MGT_VIEW;
+import static org.wso2.carbon.consent.mgt.core.util.TestUtils.closeH2Base;
+import static org.wso2.carbon.consent.mgt.core.util.TestUtils.getConnection;
+import static org.wso2.carbon.consent.mgt.core.util.TestUtils.initiateH2Base;
+import static org.wso2.carbon.consent.mgt.core.util.TestUtils.mockComponentDataHolder;
+import static org.wso2.carbon.consent.mgt.core.util.TestUtils.spyConnection;
+
+@PrepareForTest({
+                        ConsentManagerImpl.class, ConsentManagerComponentDataHolder.class,
+                        PrivilegedCarbonContext.class, KeyStoreManager.class
+                })
+public class ConsentManagerImplTest extends PowerMockTestCase {
+
+    private ConsentManager consentManager;
+    ConsentManagerConfigurationHolder configurationHolder;
+    private Connection connection;
+
+    @Mock
+    KeyStoreManager keyStoreManager;
+
+    private static List<PIICategory> piiCategories = new ArrayList<>();
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        initiateH2Base();
+        String carbonHome = Paths.get(System.getProperty("user.dir"), "target", "test-classes").toString();
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, carbonHome);
+        System.setProperty(CarbonBaseConstants.CARBON_CONFIG_DIR_PATH, Paths.get(carbonHome, "conf").toString());
+
+        DataSource dataSource = mock(DataSource.class);
+        mockComponentDataHolder(dataSource);
+
+        connection = getConnection();
+        Connection spyConnection = spyConnection(connection);
+        when(dataSource.getConnection()).thenReturn(spyConnection);
+        prepareConfigs();
+
+        PIICategory piiCategory1 = new PIICategory("PII6", "D6", true, -1234);
+        piiCategories.add(piiCategory1);
+
+        PIICategoryDAO piiCategoryDAO = new PIICategoryDAOImpl();
+        piiCategoryDAO.addPIICategory(piiCategories.get(0));
+    }
+
+    private void prepareConfigs() throws Exception {
+
+        configurationHolder = new ConsentManagerConfigurationHolder();
+
+        PurposeDAO purposeDAO = new PurposeDAOImpl();
+        configurationHolder.setPurposeDAOs(Collections.singletonList(purposeDAO));
+
+        PIICategoryDAO piiCategoryDAO = new PIICategoryDAOImpl();
+        configurationHolder.setPiiCategoryDAOs(Collections.singletonList(piiCategoryDAO));
+
+        PurposeCategoryDAO purposeCategoryDAO = new PurposeCategoryDAOImpl();
+        configurationHolder.setPurposeCategoryDAOs(Collections.singletonList(purposeCategoryDAO));
+
+        ReceiptDAO receiptDAO = new ReceiptDAOImpl();
+        configurationHolder.setReceiptDAOs(Collections.singletonList(receiptDAO));
+
+        RealmService realmService = mock(RealmService.class);
+        TenantManager tenantManager = mock(TenantManager.class);
+        UserRealm userRealm = mock(UserRealm.class);
+        AuthorizationManager authorizationManager = mock(AuthorizationManager.class);
+        when(tenantManager.getTenantId(SUPER_TENANT_DOMAIN_NAME)).thenReturn(SUPER_TENANT_ID);
+        when(tenantManager.getDomain(SUPER_TENANT_ID)).thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
+        when(userRealm.getAuthorizationManager()).thenReturn(authorizationManager);
+        when(authorizationManager.isUserAuthorized("admin", PERMISSION_CONSENT_MGT_VIEW, UI_PERMISSION_ACTION))
+                .thenReturn(true);
+        when(authorizationManager.isUserAuthorized("admin", PERMISSION_CONSENT_MGT_LIST, UI_PERMISSION_ACTION))
+                .thenReturn(true);
+        when(authorizationManager.isUserAuthorized("admin", PERMISSION_CONSENT_MGT_DELETE, UI_PERMISSION_ACTION))
+                .thenReturn(true);
+
+        configurationHolder.setRealmService(realmService);
+
+        ConsentConfigParser configParser = new ConsentConfigParser();
+        PIIController piiController = new DefaultPIIController(configParser);
+
+        configurationHolder.setPiiControllers(Collections.singletonList(piiController));
+        configurationHolder.setConfigParser(configParser);
+
+        mockCarbonContext();
+        mockKeyStoreManager();
+
+    }
+
+    @DataProvider(name = "isUserNameCaseSensitiveDataProvider")
+    public Object[][] isUserNameCaseSensitiveDataProvider() {
+
+        return new Object[][]{
+                {true},
+                {false},
+        };
+    }
+
+    @Test(dataProvider = "isUserNameCaseSensitiveDataProvider")
+    public void testConsentManagementWithCaseSensitiveUserName(boolean isUserNameCaseSensitive) throws Exception {
+
+        String collectionMethod = "Sign-up";
+        String jurisdiction = "LK";
+        String principleID1 = "subject1";
+        String language = "EN";
+        String policyUrl = "http://foo.com/policy";
+        String service1 = "foo-company";
+        String serviceDisplayName = "Foo Company";
+        String serviceDescription = "foo company";
+        String tenantDomain = "carbon.super";
+        int tenantId = -1234;
+        String consentType = "EXPLICIT";
+        String termination = "1 year";
+        String version = "KI-CR-v1.1.0";
+        String piiControllerInput =
+                "{\n" + "      \"piiController\": \"samplePiiController\",\n" + "      \"contact\": \"sample\",\n"
+                        + "      \"address\": {\n" + "        \"addressCountry\": \"country\",\n"
+                        + "        \"addressLocality\": \"locality\",\n" + "        \"addressRegion\": \"region\",\n"
+                        + "        \"postOfficeBoxNumber\": \"box\",\n" + "        \"postalCode\": \"code\",\n"
+                        + "        \"streetAddress\": \"address\"\n" + "      },\n" + "      \"email\": \"mail\",\n"
+                        + "      \"phone\": \"phone\",\n" + "      \"onBehalf\": true,\n"
+                        + "      \"piiControllerUrl\": \"sample.com\"\n" + "    }";
+
+        List<ReceiptServiceInput> serviceInputs = new ArrayList<>();
+        List<ReceiptPurposeInput> purposeInputs = new ArrayList<>();
+        List<PiiController> piiControllers = new ArrayList<>();
+        List<Integer> purposeCategoryIds = new ArrayList<>();
+        List<PIICategoryValidity> piiCategoryIds = new ArrayList<>();
+        Map<String, String> properties = new HashMap<>();
+
+        purposeCategoryIds.add(1);
+        piiCategoryIds.add(new PIICategoryValidity(1, "45"));
+        properties.put("K1", "V1");
+        properties.put("K2", "V2");
+
+        ReceiptPurposeInput purposeInput1 = new ReceiptPurposeInput();
+        purposeInput1.setPrimaryPurpose(true);
+        purposeInput1.setTermination(termination);
+        purposeInput1.setConsentType(consentType);
+        purposeInput1.setThirdPartyDisclosure(false);
+        purposeInput1.setPurposeId(1);
+        purposeInput1.setPurposeCategoryId(purposeCategoryIds);
+        purposeInput1.setPiiCategory(piiCategoryIds);
+
+        purposeInputs.add(purposeInput1);
+
+        ReceiptServiceInput serviceInput = new ReceiptServiceInput();
+        serviceInput.setPurposes(purposeInputs);
+        serviceInput.setTenantDomain(tenantDomain);
+        serviceInput.setTenantId(tenantId);
+        serviceInput.setService(service1);
+        serviceInput.setSpDisplayName(serviceDisplayName);
+        serviceInput.setSpDescription(serviceDescription);
+
+        serviceInputs.add(serviceInput);
+
+        Address address = new Address("LK", "EN", "South", "1435", "10443", "2nd Street, Colombo 03");
+        PiiController piiController = new PiiController("ACME", false, "John Wick", "johnw@acme.com", "+17834563445",
+                "http://acme.com", address);
+        piiControllers.add(piiController);
+
+        ReceiptInput receiptInput1 = new ReceiptInput();
+
+        receiptInput1.setConsentReceiptId(UUID.randomUUID().toString());
+        receiptInput1.setCollectionMethod(collectionMethod);
+        receiptInput1.setJurisdiction(jurisdiction);
+        receiptInput1.setPiiPrincipalId(principleID1);
+        receiptInput1.setLanguage(language);
+        receiptInput1.setPolicyUrl(policyUrl);
+        receiptInput1.setServices(serviceInputs);
+        receiptInput1.setTenantDomain(tenantDomain);
+        receiptInput1.setTenantId(tenantId);
+        receiptInput1.setState(ConsentConstants.ACTIVE_STATE);
+        receiptInput1.setVersion(version);
+        receiptInput1.setPiiControllerInfo(piiControllerInput);
+        receiptInput1.setProperties(properties);
+
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        ConsentManager spyConsentManager = PowerMockito.spy(consentManager);
+        PowerMockito.doReturn(isUserNameCaseSensitive).when(spyConsentManager, "isUserNameCaseSensitive", any());
+        spyConsentManager.addConsent(receiptInput1);
+        String receiptID = receiptInput1.getConsentReceiptId();
+        receiptInput1.setPiiPrincipalId("SUBJECT1");
+        spyConsentManager.addConsent(receiptInput1);
+        if (isUserNameCaseSensitive) {
+            Assert.assertEquals(spyConsentManager.getReceipt(receiptID).getState(), "ACTIVE");
+            Assert.assertEquals(spyConsentManager.getReceipt(receiptInput1.getConsentReceiptId()).getState(), "ACTIVE");
+        } else {
+            Assert.assertEquals(spyConsentManager.getReceipt(receiptID).getState(), "REVOKED");
+            Assert.assertEquals(spyConsentManager.getReceipt(receiptInput1.getConsentReceiptId()).getState(), "ACTIVE");
+        }
+        List<ReceiptListResponse> receiptListResponses = spyConsentManager
+                .searchReceipts(10, 0, "subject1", "carbon" + ".super", receiptInput1.getServices().get(0).getService(),
+                        receiptInput1.getState());
+        List<ReceiptListResponse> receiptListResponsesCaps = spyConsentManager
+                .searchReceipts(10, 0, "SUBJECT1", "carbon" + ".super", receiptInput1.getServices().get(0).getService(),
+                        receiptInput1.getState());
+        if (isUserNameCaseSensitive) {
+            Assert.assertNotEquals(receiptListResponses.get(0).getConsentReceiptId(),
+                    receiptListResponsesCaps.get(0).getConsentReceiptId());
+        } else {
+            Assert.assertEquals(receiptListResponses.get(0).getConsentReceiptId(),
+                    receiptListResponsesCaps.get(0).getConsentReceiptId());
+        }
+    }
+
+    private void mockCarbonContext() {
+
+        mockStatic(PrivilegedCarbonContext.class);
+        PrivilegedCarbonContext privilegedCarbonContext = mock(PrivilegedCarbonContext.class);
+
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
+        when(privilegedCarbonContext.getTenantDomain()).thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        when(privilegedCarbonContext.getTenantId()).thenReturn(SUPER_TENANT_ID);
+        when(privilegedCarbonContext.getUsername()).thenReturn("admin");
+    }
+
+    private void mockKeyStoreManager() throws Exception {
+
+        mockStatic(KeyStoreManager.class);
+        PowerMockito.when(KeyStoreManager.getInstance(SUPER_TENANT_ID)).thenReturn(keyStoreManager);
+
+        PowerMockito.when(keyStoreManager.getDefaultPublicKey()).thenReturn(TestUtils.getPublicKey(TestUtils
+                .loadKeyStoreFromFileSystem(TestUtils.getFilePathInConfDirectory("wso2carbon.jks"), "wso2carbon",
+                        "JKS"), "wso2carbon"));
+        PowerMockito.when(keyStoreManager.getKeyStore(anyString())).thenReturn(TestUtils
+                .loadKeyStoreFromFileSystem(TestUtils.getFilePathInConfDirectory("wso2carbon.jks"), "wso2carbon",
+                        "JKS"));
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        connection.close();
+        closeH2Base();
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.consent.mgt.core/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.carbon.consent.mgt.core.dao.impl.PurposeCategoryDAOImplTest"/>
             <class name="org.wso2.carbon.consent.mgt.core.dao.impl.ReceiptDAOImplTest"/>
             <class name="org.wso2.carbon.consent.mgt.core.InterceptingConsentManagerTest"/>
+            <class name="org.wso2.carbon.consent.mgt.core.ConsentManagerImplTest"/>
             <class name="org.wso2.carbon.consent.mgt.core.util.ConsentDBInitializerTest"/>
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
> Fix wso2/product-is#5761


## Documentation
> This fix is by default enabled which means we consider user name as case insensitive by default in consent management. To disable this fix add the following configuration to the relevant user store configuration. 

`<Property name="UseCaseSensitiveUsernameForCacheKeys">true</Property>`

- For Primary User Store:` <PRODUCT_HOME>/repository/conf/user-mgt.xml`

- For Secondary User Store: 

1. If the configuration need to be done for the super tenant, save the secondary user store definitions in `<PRODUCT_HOME>/repository/deployment/server/userstores` directory.

2. If the configuration need to be done for the tenant, save the configuration in `<PRODUCT_HOME>/repository/tenants/<tenantid>/userstores` directory.



