### PR TITLE
Add consent-mgt APIs as jars inside the identity rest dispatcher

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
+++ b/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
@@ -78,6 +78,36 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Add-2-local-repository</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <packaging>jar</packaging>
+                            <file>${project.build.directory}\${artifactId}-${version}.jar</file>
+                        </configuration>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>

--- a/components/org.wso2.carbon.consent.mgt.endpoint/src/main/resources/META-INF/cxf/consent-mgt-v1-cxf.xml
+++ b/components/org.wso2.carbon.consent.mgt.endpoint/src/main/resources/META-INF/cxf/consent-mgt-v1-cxf.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context" xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+
+    <bean class="org.wso2.carbon.consent.mgt.endpoint.impl.ConsentsApiServiceImpl"/>
+
+</beans>

--- a/components/org.wso2.carbon.consent.mgt.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.consent.mgt.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -5,6 +5,8 @@
     <context:annotation-config/>
     <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"/>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
+    <!-- For Identity Server, the jaxrs:server configuration is maintained in beans.xml of wso2/identity-rest-dispatcher
+     These configuration is maintained here as other products packing this webapp as .war -->
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
             <bean class="org.wso2.carbon.consent.mgt.endpoint.ConsentsApi"/>

--- a/features/org.wso2.carbon.consent.mgt.server.feature/pom.xml
+++ b/features/org.wso2.carbon.consent.mgt.server.feature/pom.xml
@@ -50,6 +50,12 @@
             <type>war</type>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.consent.mgt</groupId>
+            <artifactId>org.wso2.carbon.consent.mgt.endpoint</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.utils</groupId>
             <artifactId>org.wso2.carbon.database.utils.feature</artifactId>
             <version>${org.wso2.carbon.database.utils.version}</version>
@@ -79,6 +85,14 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${basedir}/src/main/resources/</outputDirectory>
                                     <destFileName>api#identity#consent-mgt#v1.0.war</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.consent.mgt</groupId>
+                                    <artifactId>org.wso2.carbon.consent.mgt.endpoint</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/api_resources</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/features/org.wso2.carbon.consent.mgt.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.consent.mgt.server.feature/resources/p2.inf
@@ -9,6 +9,7 @@ org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../depl
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/server/);\
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/server/webapps/);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.consent.mgt.server_${feature.version}/api#identity#consent-mgt#v1.0.war,target:${installFolder}/../../deployment/server/webapps/api#identity#consent-mgt#v1.0.war,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.consent.mgt.server_${feature.version}/api_resources/,target:${installFolder}/../../deployment/server/webapps/api_resources/,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources); \
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources/conf); \
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources/conf/templates); \


### PR DESCRIPTION
Add consent-mgt as jars and deploy them as jars inside API rest dispatcher 
Related to https://github.com/wso2/product-is/issues/11425



As `api#identity#consent-mgt#v1.0.war` is packed by other products, those wars will be kept as it is in the features and new jars will be copied inside `api_resources` then moved to api-dispatcher and wars will be removed in the product-is. Other products can remove `api_resources` folder and keep the wars.