### PR TITLE
Remove Encoding for claim group

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-finish-purpose.jsp
+++ b/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-finish-purpose.jsp
@@ -76,7 +76,7 @@
         List<PiiCategoryDTO> categories = new ArrayList<PiiCategoryDTO>();
         name = Encode.forJavaScript(request.getParameter("purposeName"));
         String description = Encode.forJavaScript(request.getParameter("purpose.description"));
-        String group = Encode.forJavaScript(request.getParameter("group"));
+        String group = request.getParameter("group");
         String groupType = Encode.forJavaScript(request.getParameter("groupType"));
         int categoryCount = Integer.parseInt(request.getParameter("claimrow_name_count"));
         for (int i = 0; i < categoryCount; i++) {


### PR DESCRIPTION
## Purpose
Remove encoding for claim group since this breaks UI of Consent Purposes: SELF-SIGNUP, and encoding this field is not necessary since the provided value won't be used in any js executions

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes