### PR TITLE
Add a version range for consent mgt ui to fix u2 issues

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.ui/pom.xml
+++ b/components/org.wso2.carbon.consent.mgt.ui/pom.xml
@@ -78,7 +78,7 @@
                             org.apache.commons.collections; version="${commons.collections.version.range}",
                             org.wso2.carbon.ui.*; version="${carbon.core.version.range}",
                             org.wso2.carbon.utils.*; version="${carbon.core.version.range}",
-                            org.wso2.carbon.consent.mgt.*;version=${project.version},
+                            org.wso2.carbon.consent.mgt.*; version="${consent.mgt.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.core.version.range}",
                             org.wso2.carbon.user.api.*; version="${carbon.api.version.range}",
                             org.wso2.carbon.context.*; version="${carbon.core.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,7 @@
 
     <properties>
 
+        <consent.mgt.version.range>[2.0.0, 3.0.0]</consent.mgt.version.range>
         <carbon.p2.plugin.version>5.2.3</carbon.p2.plugin.version>
         <org.apache.felix.annotations.version>1.2.10</org.apache.felix.annotations.version>
         <eclipse.osgi.version>3.5.100.v20160504-1419</eclipse.osgi.version>


### PR DESCRIPTION
## Purpose
With versioning in the import packages, when the org.wso2.carbon.consent.mgt.ui jar version is different than the org.wso2.carbon.consent.mgt.core due to the 4th digit of the version, bundle will not get activate properly.

fixes wso2/product-apim#11742