### PR TITLE
[Consent Mgt] Add correlationID support

### DIFF
--- a/components/org.wso2.carbon.api.server.consent.mgt/src/gen/java/org/wso2/carbon/consent/mgt/endpoint/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.api.server.consent.mgt/src/gen/java/org/wso2/carbon/consent/mgt/endpoint/dto/ErrorDTO.java
@@ -23,6 +23,8 @@ public class ErrorDTO  {
   
   private String description = null;
 
+  private String ref = null;
+
   
   /**
    **/
@@ -59,6 +61,13 @@ public class ErrorDTO  {
     this.description = description;
   }
 
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("traceId")
+  public String getRef() {return ref;}
+  public void setRef(String ref) {this.ref = ref;}
+
   
 
   @Override
@@ -69,6 +78,9 @@ public class ErrorDTO  {
     sb.append("  code: ").append(code).append("\n");
     sb.append("  message: ").append(message).append("\n");
     sb.append("  description: ").append(description).append("\n");
+    if(!ref.isEmpty()) {
+      sb.append("  traceId: ").append(ref).append("\n");
+    }
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.api.server.consent.mgt/src/main/java/org/wso2/carbon/consent/mgt/endpoint/util/ConsentEndpointUtils.java
+++ b/components/org.wso2.carbon.api.server.consent.mgt/src/main/java/org/wso2/carbon/consent/mgt/endpoint/util/ConsentEndpointUtils.java
@@ -119,7 +119,7 @@ public class ConsentEndpointUtils {
             ref = MDC.get(ConsentConstants.CORRELATION_ID_MDC).toString();
         } else {
             ref = UUID.randomUUID().toString();
-
+            MDC.put(ConsentConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.api.server.consent.mgt/src/main/java/org/wso2/carbon/consent/mgt/endpoint/util/ConsentEndpointUtils.java
+++ b/components/org.wso2.carbon.api.server.consent.mgt/src/main/java/org/wso2/carbon/consent/mgt/endpoint/util/ConsentEndpointUtils.java
@@ -114,12 +114,9 @@ public class ConsentEndpointUtils {
      * @return correlation-id
      */
     public static String getCorrelation() {
-        String ref;
+        String ref = null;
         if (isCorrelationIDPresent()) {
             ref = MDC.get(ConsentConstants.CORRELATION_ID_MDC).toString();
-        } else {
-            ref = UUID.randomUUID().toString();
-            MDC.put(ConsentConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.api.server.consent.mgt/src/main/java/org/wso2/carbon/consent/mgt/endpoint/util/ConsentEndpointUtils.java
+++ b/components/org.wso2.carbon.api.server.consent.mgt/src/main/java/org/wso2/carbon/consent/mgt/endpoint/util/ConsentEndpointUtils.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.consent.mgt.endpoint.util;
 
 import org.apache.commons.logging.Log;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.consent.mgt.core.constant.ConsentConstants;
 import org.wso2.carbon.consent.mgt.core.model.PIICategory;
@@ -54,6 +55,7 @@ import org.wso2.carbon.consent.mgt.endpoint.exception.NotFoundException;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -95,6 +97,31 @@ public class ConsentEndpointUtils {
         ErrorDTO errorDTO = getErrorDTO(ConsentConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, description, code);
         logDebug(log, e);
         return new BadRequestException(errorDTO);
+    }
+
+    /**
+     * Check whether correlation id present in the log MDC
+     *
+     * @return whether the correlation id is present
+     */
+    public static boolean isCorrelationIDPresent() {
+        return MDC.get(ConsentConstants.CORRELATION_ID_MDC) != null;
+    }
+
+    /**
+     * Get correlation id of current thread
+     *
+     * @return correlation-id
+     */
+    public static String getCorrelation() {
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(ConsentConstants.CORRELATION_ID_MDC).toString();
+        } else {
+            ref = UUID.randomUUID().toString();
+
+        }
+        return ref;
     }
 
     /**
@@ -225,6 +252,7 @@ public class ConsentEndpointUtils {
         errorDTO.setCode(code);
         errorDTO.setMessage(message);
         errorDTO.setDescription(description);
+        errorDTO.setRef(getCorrelation());
         return errorDTO;
     }
 

--- a/components/org.wso2.carbon.api.server.consent.mgt/src/main/resources/carbon-consent-management.yaml
+++ b/components/org.wso2.carbon.api.server.consent.mgt/src/main/resources/carbon-consent-management.yaml
@@ -748,6 +748,8 @@ definitions:
         type: string
       description:
         type: string
+      traceId:
+        type: string
 #-----------------------------------------------------
 
 #-----------------------------------------------------

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
@@ -79,6 +79,8 @@ public class ConsentConstants {
     public static final String LIST_RECEIPT = "LIST_RECEIPT";
     public static final String REVOKE_RECEIPT = "REVOKE_RECEIPT";
 
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
+
     public enum ErrorMessages {
         ERROR_CODE_DATABASE_CONNECTION("CM_00001", "Error when getting a database connection object from the Consent" +
                 " data source."),


### PR DESCRIPTION
### Purpose
> This PR add correlationID support for consent managment REST APIs. 

### Goals
> This correlationID (returned as `traceId`) will help in tracking issues and to follow up on the errors. 

### Approach
> Since the correlationID is set in MDC, first we check for any available ID and if not send a random UUID for tracking purposes.

