### PR TITLE
Encode claim values before form submission in add consent purposes

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-finish-purpose.jsp
+++ b/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-finish-purpose.jsp
@@ -35,6 +35,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="java.util.Base64" %>
 <jsp:include page="../dialog/display_messages.jsp"/>
 
 <%
@@ -81,6 +82,7 @@
         int categoryCount = Integer.parseInt(request.getParameter("claimrow_name_count"));
         for (int i = 0; i < categoryCount; i++) {
             String claimInfo = request.getParameter("claimrow_name_wso2_" + i);
+            claimInfo = new String(Base64.getDecoder().decode(claimInfo), StandardCharsets.UTF_8);
             boolean isPIICategoryMandatory = request.getParameter("claimrow_mandatory_" + i) != null;
 
             if (StringUtils.isNotBlank(claimInfo)) {

--- a/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-purpose.jsp
+++ b/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-purpose.jsp
@@ -129,9 +129,19 @@
                 }
             }
             function doSubmit() {
+                doEncode();
                 document.dataForm.submit();
             }
         }
+
+        function doEncode() {
+            var claimRawCount = $('#claimrow_id_count').val();
+            for (let i = 0; i < claimRawCount; i++) {
+                var claimValue = $("[name=claimrow_name_wso2_" + i + "] option:selected").val();
+                $("[name=claimrow_name_wso2_" + i + "] option:selected").val(btoa(claimValue));
+            }
+        }
+
         function doValidationForMandatoryEmailPIICategory() {
             var count = document.getElementsByName("claimrow_name_count")[0];
             for (let i = 0; i < count.value; i++) {


### PR DESCRIPTION
Resolves part of [product-is #13987](https://github.com/wso2/product-is/issues/13987)

Fixes the issue mentioned in product-is #13987 for 

- PII Categories in adding consent purposes

by base64 encoding the claim values before form submission.