### PR TITLE
Fix cannot add consent purpose with pii category without a selected claim

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-purpose.jsp
+++ b/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-purpose.jsp
@@ -189,15 +189,27 @@
             <%}%>
         }
 
-        var deleteClaimRows = [];
         function deleteClaimRow(obj) {
-            if (jQuery(obj).parent().prev().children()[0].value != '') {
-                deleteClaimRows.push(jQuery(obj).parent().prev().children()[0].value);
+            var currentDeletingRowName = jQuery(obj).parent().prev().prev().children()[0].name;
+            var currentDeletingRowId = extractClaimRowIdFromName(currentDeletingRowName);
+
+            for (let i = currentDeletingRowId + 1; i < claimRowId + 1; i++) {
+                $("[name=claimrow_name_wso2_" + i + "]").attr('name', 'claimrow_name_wso2_' + (i - 1));
+                $("[name=claimrow_mandatory_" + i + "]").attr('name', 'claimrow_mandatory_' + (i - 1));
             }
+
+            claimRowId--;
+            $("#claimrow_id_count").val(claimRowId + 1);
+
             jQuery(obj).parent().parent().remove();
             if ($(jQuery('#claimAddTable tr')).length == 1) {
                 $(jQuery('#claimAddTable')).toggle();
             }
+        }
+
+        function extractClaimRowIdFromName(rowName) {
+            nameArr = rowName.split("_");
+            return Number(nameArr[nameArr.length - 1]);
         }
         
         var claimRowId = -1;

--- a/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-purpose.jsp
+++ b/components/org.wso2.carbon.consent.mgt.ui/src/main/resources/web/consent/add-purpose.jsp
@@ -156,6 +156,17 @@
             return false;
         }
 
+        function validateNonEmptyPIICategories() {
+            var count = document.getElementsByName("claimrow_name_count")[0];
+            for (let i = 0; i < count.value; i++) {
+                var claim = document.getElementsByName("claimrow_name_wso2_" + i);
+                if (claim && claim[0] && !claim[0].value){
+                    return false;
+                }
+            }
+            return true;
+        }
+
         function doValidation() {
             var reason = "";
             reason = validateEmpty("purposeName");
@@ -175,6 +186,11 @@
             
             if (reason != "") {
                 CARBON.showWarningDialog("Purpose group type cannot be empty");
+                return false;
+            }
+
+            if (!validateNonEmptyPIICategories()) {
+                CARBON.showWarningDialog("Claim URI must be selected for all added PII categories");
                 return false;
             }
 


### PR DESCRIPTION
This PR contains fixes for,
1. Inability to add a consent purpose after deleting one or more added PII categories
2. Inability to add a consent purpose with one or more PII categories without selected claims

Resolves : https://github.com/wso2/product-is/issues/14104 

