### PR TITLE
Third-party dependency upgrade

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
+++ b/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
@@ -154,6 +154,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-xml</artifactId>
                 </exclusion>
@@ -241,6 +245,11 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>${javax.validation-api}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,11 @@
                 <version>${fasterxml.jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax.validation-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger.jaxrs.version}</version>
@@ -368,6 +373,7 @@
         <apache.httpclient.version>4.5.8</apache.httpclient.version>
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
         <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
+        <javax.validation-api>2.0.1.Final</javax.validation-api>
 
         <!--swagger2cxf.maven.plugin.version>1.0-SNAPSHOT</swagger2cxf.maven.plugin.version-->
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>


### PR DESCRIPTION
Related PR - https://github.com/wso2-support/carbon-consent-management/pull/54
validation-api has been updated from 1.1.0.Final to 2.0.1.Final from this PR

The following component will be updated from this PR

- ./repository/deployment/server/webapps/api#identity#consent-mgt#v1.0/WEB-INF/lib/validation-api-1.1.0.Final.jar