### PR TITLE
Third-party dependency upgrade

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
+++ b/components/org.wso2.carbon.consent.mgt.endpoint/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-xml</artifactId>
                 </exclusion>
@@ -128,6 +132,11 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>${javax.validation-api}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax.validation-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger.jaxrs.version}</version>
@@ -303,6 +308,7 @@
         <org.json.wso2.version>3.0.0.wso2v1</org.json.wso2.version>
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
+        <javax.validation-api>2.0.1.Final</javax.validation-api>
 
         <!--swagger2cxf.maven.plugin.version>1.0-SNAPSHOT</swagger2cxf.maven.plugin.version-->
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1017

Related PR - https://github.com/wso2-support/carbon-consent-management/pull/54
validation-api has been updated from 1.1.0.Final to 2.0.1.Final from this PR

The following component will be updated from this PR

- ./repository/deployment/server/webapps/api#identity#consent-mgt#v1.0/WEB-INF/lib/validation-api-1.1.0.Final.jar