### PR TITLE
Fix NPE in list consent endpoint

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -698,7 +698,7 @@ public class ConsentManagerImpl implements ConsentManager {
                 log.debug("Limit is not defied the request, default to: " + limit);
             }
         }
-        if (!isUserNameCaseSensitive(piiPrincipalId)) {
+        if (StringUtils.isNotBlank(piiPrincipalId) && !isUserNameCaseSensitive(piiPrincipalId)) {
             piiPrincipalId = getLowerCaseUserName(piiPrincipalId);
         }
         List<ReceiptListResponse> receiptListResponses = getReceiptsDAO(receiptDAOs).searchReceipts(limit, offset,


### PR DESCRIPTION
### Purpose

This PR fixes the Null Pointer Exception that occurs when invoking the List Consents endpoint [1] without the `piiPrincipalId` parameter. The solution is to do a simple null check within the `searchReceipts` method.

[1] https://docs.wso2.com/display/IS510/apidocs/Consent-management-apis/#!/operations#Consent#consentsGet

### Related Issue 
https://github.com/wso2/product-is/issues/15419