### PR TITLE
Upgrade swagger-jaxrs version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <eclipse.osgi.version>3.5.100.v20160504-1419</eclipse.osgi.version>
         <carbon.core.version>4.5.0</carbon.core.version>
         <slf4j.api.version>1.7.26</slf4j.api.version>
-        <swagger.jaxrs.version>1.6.2</swagger.jaxrs.version>
+        <swagger.jaxrs.version>1.6.9</swagger.jaxrs.version>
         <jaxrx.jsr311.api.version>1.1.1</jaxrx.jsr311.api.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <springframework.version>5.1.7.RELEASE</springframework.version>


### PR DESCRIPTION
### Purpose
To upgrade the swagger-jaxrs version to fix known vulnerabilities.

Note:
Previously, in [carbon-consent-management](https://github.com/wso2/carbon-consent-management/blob/master/pom.xml) master has used `<swagger.jaxrs.version>1.6.2</swagger.jaxrs.version>` which is vulnerable against:

[CVE-2022-42004](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42004)
[CVE-2022-42003](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003)
[CVE-2022-4065](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4065)
[CVE-2021-42550](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550)
[CVE-2021-29425](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
[CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518)