### PR TITLE
Make Consent Manager component activation success log level to debug

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/internal/ConsentManagerComponent.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/internal/ConsentManagerComponent.java
@@ -110,7 +110,7 @@ public class ConsentManagerComponent {
                     (configHolder, consentMgtInterceptors), null);
             bundleContext.registerService(PrivilegedConsentManager.class.getName(),
                     new PrivilegedConsentManagerImpl(configHolder, consentMgtInterceptors), null);
-            log.info("ConsentManagerComponent is activated.");
+            log.debug("ConsentManagerComponent is activated.");
         } catch (Throwable e) {
             log.error("Error while activating ConsentManagerComponent.", e);
         }


### PR DESCRIPTION
### Proposed changes in this pull request

$subject to avoid unnecessary logs to be printed during the product startup.

Related to,
- https://github.com/wso2/product-is/issues/20778