### PR TITLE
[2.5.x] Upgrade axis2 and axiom versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,9 +305,9 @@
         <maven.war.plugin.version>3.2.2</maven.war.plugin.version>
         <build.helper.plugin.version>3.0.0</build.helper.plugin.version>
         <encoder.wso2.version>1.2.0.wso2v2</encoder.wso2.version>
-        <axis2.wso2.version>1.6.2.wso2v13</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v105</axis2.wso2.version>
         <org.json.wso2.version>3.0.0.wso2v1</org.json.wso2.version>
-        <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
+        <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
 
         <!--swagger2cxf.maven.plugin.version>1.0-SNAPSHOT</swagger2cxf.maven.plugin.version-->
@@ -320,7 +320,7 @@
         <commons.lang.version.range>[2.6.0, 3.0.0)</commons.lang.version.range>
         <commons.logging.version.range>[1.2, 2.0)</commons.logging.version.range>
         <slf4j.version.range>[1.6.1, 3.0.0)</slf4j.version.range>
-        <axis2.osgi.version.range>[1.6.1.wso2v12, 2.0.0)</axis2.osgi.version.range>
+        <axis2.osgi.version.range>[1.6.1.wso2v105, 2.0.0)</axis2.osgi.version.range>
         <claim.metadata.version.range>[5.0.0,6.0.0)</claim.metadata.version.range>
         <org.json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</org.json.wso2.version.range>
         <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>


### PR DESCRIPTION
## Purpose
This PR adds the following dependency upgrades:

- axis2 version: 1.6.2-wso2v13 to 1.6.1-wso2v105
- axiom version: 1.2.11-wso2v10 to 1.2.11-wso2v29 