### PR TITLE
Improve event handling in Consent V2 API

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentEventPublisherProxy.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentEventPublisherProxy.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementServerExcepti
 import org.wso2.carbon.consent.mgt.core.internal.ConsentManagerComponentDataHolder;
 import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
@@ -32,6 +33,7 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.AUTHZ_STATUS;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_EVENT_PUBLISHING;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.POST_ADD_PURPOSE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.POST_ADD_PURPOSE_VERSION;
@@ -52,10 +54,13 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.Interce
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.PRE_REVOKE_RECEIPT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.PRE_SET_LATEST_PURPOSE_VERSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_ID;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_NAME;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_UUID;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_VERSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_VERSION_LABEL;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.RECEIPT_ID;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.RECEIPT_INPUT;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.SET_AS_LATEST;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.VERSION_ID;
 
 /**
@@ -65,9 +70,6 @@ public class ConsentEventPublisherProxy {
 
     private static final Log LOG = LogFactory.getLog(ConsentEventPublisherProxy.class);
     private static final ConsentEventPublisherProxy proxy = new ConsentEventPublisherProxy();
-    private static final String TENANT_DOMAIN = "tenantDomain";
-    private static final String PURPOSE_VERSION = "purposeVersion";
-    private static final String PURPOSE_NAME = "purposeName";
 
     private ConsentEventPublisherProxy() {
     }
@@ -83,7 +85,7 @@ public class ConsentEventPublisherProxy {
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
         props.put(PURPOSE_NAME, purposeName);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_ADD_PURPOSE, props));
     }
 
@@ -92,7 +94,7 @@ public class ConsentEventPublisherProxy {
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
         props.put(PURPOSE_NAME, purposeName);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_ADD_PURPOSE, props));
     }
 
@@ -101,7 +103,7 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_DELETE_PURPOSE, props));
     }
 
@@ -109,27 +111,30 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_DELETE_PURPOSE, props));
     }
 
     public void publishPreAddPurposeVersionWithException(String purposeUuid, PurposeVersion purposeVersion,
+                                                         boolean setAsLatest,
                                                          String tenantDomain) throws ConsentManagementException {
 
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
         props.put(PURPOSE_VERSION, purposeVersion);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(SET_AS_LATEST, setAsLatest);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_ADD_PURPOSE_VERSION, props));
     }
 
     public void publishPostAddPurposeVersion(String purposeUuid, PurposeVersion purposeVersion,
-                                             String tenantDomain) {
+                                             boolean setAsLatest, String tenantDomain) {
 
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
         props.put(PURPOSE_VERSION, purposeVersion);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(SET_AS_LATEST, setAsLatest);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_ADD_PURPOSE_VERSION, props));
     }
 
@@ -139,7 +144,7 @@ public class ConsentEventPublisherProxy {
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
         props.put(VERSION_ID, versionUuid);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_DELETE_PURPOSE_VERSION, props));
     }
 
@@ -148,7 +153,7 @@ public class ConsentEventPublisherProxy {
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_UUID, purposeUuid);
         props.put(VERSION_ID, versionUuid);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_DELETE_PURPOSE_VERSION, props));
     }
 
@@ -159,7 +164,7 @@ public class ConsentEventPublisherProxy {
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_ID, purposeUUID);
         props.put(PURPOSE_VERSION_LABEL, versionLabel);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_SET_LATEST_PURPOSE_VERSION, props));
     }
 
@@ -168,7 +173,7 @@ public class ConsentEventPublisherProxy {
         Map<String, Object> props = new HashMap<>();
         props.put(PURPOSE_ID, purposeUUID);
         props.put(PURPOSE_VERSION_LABEL, versionLabel);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_SET_LATEST_PURPOSE_VERSION, props));
     }
 
@@ -178,9 +183,9 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_ID, consentId);
-        props.put("USER_ID", userId);
-        props.put("AUTH_STATUS", authStatus);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.USER_ID, userId);
+        props.put(AUTHZ_STATUS, authStatus);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_AUTHORIZE_CONSENT, props));
     }
 
@@ -189,9 +194,9 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_ID, consentId);
-        props.put("USER_ID", userId);
-        props.put("AUTH_STATUS", authStatus);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.USER_ID, userId);
+        props.put(AUTHZ_STATUS, authStatus);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_AUTHORIZE_CONSENT, props));
     }
 
@@ -200,7 +205,7 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_INPUT, receiptInput);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_ADD_RECEIPT, props));
     }
 
@@ -208,7 +213,7 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_INPUT, receiptInput);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_ADD_RECEIPT, props));
     }
 
@@ -217,7 +222,7 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_ID, receiptId);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_REVOKE_RECEIPT, props));
     }
 
@@ -225,7 +230,7 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_ID, receiptId);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_REVOKE_RECEIPT, props));
     }
 
@@ -234,7 +239,7 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_ID, receiptId);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_DELETE_RECEIPT, props));
     }
 
@@ -242,7 +247,7 @@ public class ConsentEventPublisherProxy {
 
         Map<String, Object> props = new HashMap<>();
         props.put(RECEIPT_ID, receiptId);
-        props.put(TENANT_DOMAIN, tenantDomain);
+        props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_DELETE_RECEIPT, props));
     }
 

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentEventPublisherProxy.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentEventPublisherProxy.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementServerException;
 import org.wso2.carbon.consent.mgt.core.internal.ConsentManagerComponentDataHolder;
+import org.wso2.carbon.consent.mgt.core.model.Purpose;
 import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -54,8 +55,7 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.Interce
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.PRE_REVOKE_RECEIPT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.PRE_SET_LATEST_PURPOSE_VERSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_ID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_NAME;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_UUID;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_VERSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_VERSION_LABEL;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.RECEIPT_ID;
@@ -79,21 +79,19 @@ public class ConsentEventPublisherProxy {
         return proxy;
     }
 
-    public void publishPreAddPurposeWithException(String purposeUuid, String purposeName, String tenantDomain)
+    public void publishPreAddPurposeWithException(Purpose purpose, String tenantDomain)
             throws ConsentManagementException {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
-        props.put(PURPOSE_NAME, purposeName);
+        props.put(PURPOSE, purpose);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_ADD_PURPOSE, props));
     }
 
-    public void publishPostAddPurpose(String purposeUuid, String purposeName, String tenantDomain) {
+    public void publishPostAddPurpose(Purpose purpose, String tenantDomain) {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
-        props.put(PURPOSE_NAME, purposeName);
+        props.put(PURPOSE, purpose);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_ADD_PURPOSE, props));
     }
@@ -102,7 +100,7 @@ public class ConsentEventPublisherProxy {
             throws ConsentManagementException {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
+        props.put(PURPOSE_ID, purposeUuid);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_DELETE_PURPOSE, props));
     }
@@ -110,7 +108,7 @@ public class ConsentEventPublisherProxy {
     public void publishPostDeletePurpose(String purposeUuid, String tenantDomain) {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
+        props.put(PURPOSE_ID, purposeUuid);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_DELETE_PURPOSE, props));
     }
@@ -120,7 +118,7 @@ public class ConsentEventPublisherProxy {
                                                          String tenantDomain) throws ConsentManagementException {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
+        props.put(PURPOSE_ID, purposeUuid);
         props.put(PURPOSE_VERSION, purposeVersion);
         props.put(SET_AS_LATEST, setAsLatest);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
@@ -131,7 +129,7 @@ public class ConsentEventPublisherProxy {
                                              boolean setAsLatest, String tenantDomain) {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
+        props.put(PURPOSE_ID, purposeUuid);
         props.put(PURPOSE_VERSION, purposeVersion);
         props.put(SET_AS_LATEST, setAsLatest);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
@@ -142,7 +140,7 @@ public class ConsentEventPublisherProxy {
                                                             String tenantDomain) throws ConsentManagementException {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
+        props.put(PURPOSE_ID, purposeUuid);
         props.put(VERSION_ID, versionUuid);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEventWithException(new Event(PRE_DELETE_PURPOSE_VERSION, props));
@@ -151,7 +149,7 @@ public class ConsentEventPublisherProxy {
     public void publishPostDeletePurposeVersion(String purposeUuid, String versionUuid, String tenantDomain) {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(PURPOSE_UUID, purposeUuid);
+        props.put(PURPOSE_ID, purposeUuid);
         props.put(VERSION_ID, versionUuid);
         props.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         doPublishEvent(new Event(POST_DELETE_PURPOSE_VERSION, props));

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -40,7 +40,6 @@ import org.wso2.carbon.identity.core.model.ExpressionNode;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP_TYPE;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -171,11 +171,11 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
-                listener.preAddPurpose(purpose.getUuid(), purpose.getName(), tenantDomain);
+                listener.preAddPurpose(String.valueOf(purpose.getId()), purpose.getName(), tenantDomain);
             }
         }
         ConsentEventPublisherProxy.getInstance().publishPreAddPurposeWithException(
-                purpose.getUuid(), purpose.getName(), tenantDomain);
+                String.valueOf(purpose.getId()), purpose.getName(), tenantDomain);
 
         ConsentMessageContext context = new ConsentMessageContext();
         ConsentInterceptorTemplate<Purpose, ConsentManagementException>

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.core.model.ExpressionNode;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP_TYPE;
@@ -171,7 +172,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
-                listener.preAddPurpose(String.valueOf(purpose.getId()), purpose.getName(), tenantDomain);
+                listener.preAddPurpose(purpose, tenantDomain);
             }
         }
         ConsentEventPublisherProxy.getInstance().publishPreAddPurposeWithException(
@@ -193,10 +194,10 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 .getResult();
 
         ConsentEventPublisherProxy.getInstance().publishPostAddPurpose(
-                result.getUuid(), result.getName(), tenantDomain);
+                String.valueOf(result.getId()), result.getName(), tenantDomain);
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
-                listener.postAddPurpose(result.getUuid(), result.getName(), tenantDomain);
+                listener.postAddPurpose(result, tenantDomain);
             }
         }
         return result;
@@ -210,7 +211,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
-                listener.preAddPurpose(purpose.getUuid(), purpose.getName(), tenantDomain);
+                listener.preAddPurpose(purpose, tenantDomain);
             }
         }
         ConsentEventPublisherProxy.getInstance().publishPreAddPurposeWithException(
@@ -235,7 +236,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 result.getUuid(), result.getName(), tenantDomain);
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
-                listener.postAddPurpose(result.getUuid(), result.getName(), tenantDomain);
+                listener.postAddPurpose(result, tenantDomain);
             }
         }
         return result;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -174,8 +174,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 listener.preAddPurpose(purpose, tenantDomain);
             }
         }
-        ConsentEventPublisherProxy.getInstance().publishPreAddPurposeWithException(
-                String.valueOf(purpose.getId()), purpose.getName(), tenantDomain);
+        ConsentEventPublisherProxy.getInstance().publishPreAddPurposeWithException(purpose, tenantDomain);
 
         ConsentMessageContext context = new ConsentMessageContext();
         ConsentInterceptorTemplate<Purpose, ConsentManagementException>
@@ -192,8 +191,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 .intercept(POST_ADD_PURPOSE, properties -> properties.put(PURPOSE, purpose))
                 .getResult();
 
-        ConsentEventPublisherProxy.getInstance().publishPostAddPurpose(
-                String.valueOf(result.getId()), result.getName(), tenantDomain);
+        ConsentEventPublisherProxy.getInstance().publishPostAddPurpose(result, tenantDomain);
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
                 listener.postAddPurpose(result, tenantDomain);
@@ -213,8 +211,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 listener.preAddPurpose(purpose, tenantDomain);
             }
         }
-        ConsentEventPublisherProxy.getInstance().publishPreAddPurposeWithException(
-                purpose.getUuid(), purpose.getName(), tenantDomain);
+        ConsentEventPublisherProxy.getInstance().publishPreAddPurposeWithException(purpose, tenantDomain);
 
         ConsentMessageContext context = new ConsentMessageContext();
         ConsentInterceptorTemplate<Purpose, ConsentManagementException>
@@ -231,8 +228,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 .intercept(POST_ADD_PURPOSE, properties -> properties.put(PURPOSE, purpose))
                 .getResult();
 
-        ConsentEventPublisherProxy.getInstance().publishPostAddPurpose(
-                result.getUuid(), result.getName(), tenantDomain);
+        ConsentEventPublisherProxy.getInstance().publishPostAddPurpose(result, tenantDomain);
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
                 listener.postAddPurpose(result, tenantDomain);

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -1121,7 +1121,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
             }
         }
         ConsentEventPublisherProxy.getInstance().publishPreAddPurposeVersionWithException(
-                purposeUuid, purposeVersion, tenantDomain);
+                purposeUuid, purposeVersion, setAsLatest, tenantDomain);
 
         ConsentMessageContext context = new ConsentMessageContext();
         ConsentInterceptorTemplate<PurposeVersion, ConsentManagementException>
@@ -1144,7 +1144,8 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
                 })
                 .getResult();
 
-        ConsentEventPublisherProxy.getInstance().publishPostAddPurposeVersion(purposeUuid, result, tenantDomain);
+        ConsentEventPublisherProxy.getInstance().publishPostAddPurposeVersion(purposeUuid, result, setAsLatest,
+                tenantDomain);
         for (ConsentManagementListener listener : listeners) {
             if (listener.isEnable()) {
                 listener.postAddPurposeVersion(purposeUuid, result, tenantDomain);

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
@@ -72,6 +72,9 @@ public class ConsentConstants {
     public static final String GROUP = "GROUP";
     public static final String GROUP_TYPE = "GROUP_TYPE";
     public static final String PURPOSE_VERSION_LABEL = "PURPOSE_VERSION_LABEL";
+    public static final String PURPOSE_VERSION = "PURPOSE_VERSION";
+    public static final String AUTHZ_STATUS = "AUTHZ_STATUS";
+    public static final String SET_AS_LATEST = "SET_AS_LATEST";
 
     public static final String MY_SQL = "MySQL";
     public static final String MARIADB = "MariaDB";

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/AbstractConsentManagementListener.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/AbstractConsentManagementListener.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.consent.mgt.core.listener;
 
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
+import org.wso2.carbon.consent.mgt.core.model.Purpose;
 import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
 import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
@@ -41,13 +42,13 @@ public abstract class AbstractConsentManagementListener implements ConsentManage
     }
 
     @Override
-    public void preAddPurpose(String purposeUuid, String purposeName, String tenantDomain)
+    public void preAddPurpose(Purpose purpose, String tenantDomain)
             throws ConsentManagementException {
 
     }
 
     @Override
-    public void postAddPurpose(String purposeUuid, String purposeName, String tenantDomain)
+    public void postAddPurpose(Purpose purpose, String tenantDomain)
             throws ConsentManagementException {
 
     }

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementAuditLogger.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementAuditLogger.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.consent.mgt.core.listener;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.wso2.carbon.consent.mgt.core.model.Purpose;
 import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptPurposeInput;
@@ -78,13 +79,14 @@ public class ConsentManagementAuditLogger extends AbstractConsentManagementListe
     }
 
     @Override
-    public void postAddPurpose(String purposeUuid, String purposeName, String tenantDomain) {
+    public void postAddPurpose(Purpose purpose, String tenantDomain) {
 
         JSONObject data = new JSONObject();
-        if (StringUtils.isNotBlank(purposeName)) {
-            data.put(DATA_NAME, purposeName);
+        if (purpose != null && StringUtils.isNotBlank(purpose.getName())) {
+            data.put(DATA_NAME, purpose.getName());
         }
-        buildAuditLog(purposeUuid, TARGET_PURPOSE, ACTION_ADD_PURPOSE, data);
+        String purposeId = purpose != null ? purpose.getUuid() : String.valueOf(purpose.getId());
+        buildAuditLog(purposeId, TARGET_PURPOSE, ACTION_ADD_PURPOSE, data);
     }
 
     @Override

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementAuditLogger.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementAuditLogger.java
@@ -60,7 +60,6 @@ public class ConsentManagementAuditLogger extends AbstractConsentManagementListe
     private static final String DATA_VERSION_LABEL = "versionLabel";
     private static final String DATA_PII_PRINCIPAL_ID = "piiPrincipalId";
     private static final String DATA_STATE = "state";
-    private static final String DATA_SERVICE_COUNT = "serviceCount";
     private static final String DATA_SERVICE_NAMES = "serviceNames";
     private static final String DATA_PURPOSE_NAMES = "purposeNames";
     private static final String DATA_USER_ID = "userId";
@@ -124,7 +123,6 @@ public class ConsentManagementAuditLogger extends AbstractConsentManagementListe
         data.put(DATA_PII_PRINCIPAL_ID, LoggerUtils.getMaskedContent(receiptInput.getPiiPrincipalId()));
         data.put(DATA_STATE, receiptInput.getState());
         if (receiptInput.getServices() != null) {
-            data.put(DATA_SERVICE_COUNT, receiptInput.getServices().size());
             JSONArray serviceNames = extractServiceNames(receiptInput);
             if (serviceNames.length() > 0) {
                 data.put(DATA_SERVICE_NAMES, serviceNames);

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementAuditLogger.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementAuditLogger.java
@@ -81,11 +81,12 @@ public class ConsentManagementAuditLogger extends AbstractConsentManagementListe
     @Override
     public void postAddPurpose(Purpose purpose, String tenantDomain) {
 
-        JSONObject data = new JSONObject();
-        if (purpose != null && StringUtils.isNotBlank(purpose.getName())) {
-            data.put(DATA_NAME, purpose.getName());
+        if (purpose == null) {
+            return;
         }
-        String purposeId = purpose != null ? purpose.getUuid() : String.valueOf(purpose.getId());
+        JSONObject data = new JSONObject();
+        data.put(DATA_NAME, purpose.getName());
+        String purposeId = StringUtils.isNotBlank(purpose.getUuid()) ? purpose.getUuid() : String.valueOf(purpose.getId());
         buildAuditLog(purposeId, TARGET_PURPOSE, ACTION_ADD_PURPOSE, data);
     }
 
@@ -98,11 +99,12 @@ public class ConsentManagementAuditLogger extends AbstractConsentManagementListe
     @Override
     public void postAddPurposeVersion(String purposeUuid, PurposeVersion purposeVersion, String tenantDomain) {
 
+        if (purposeVersion == null) {
+            return;
+        }
         JSONObject data = new JSONObject();
         data.put(DATA_PURPOSE_ID, purposeUuid);
-        if (purposeVersion != null) {
-            data.put(DATA_VERSION_LABEL, purposeVersion.getVersion());
-        }
+        data.put(DATA_VERSION_LABEL, purposeVersion.getVersion());
         String versionUuid = purposeVersion != null ? purposeVersion.getUuid() : purposeUuid;
         buildAuditLog(versionUuid, TARGET_PURPOSE_VERSION, ACTION_ADD_PURPOSE_VERSION, data);
     }

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementListener.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/listener/ConsentManagementListener.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.consent.mgt.core.listener;
 
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
+import org.wso2.carbon.consent.mgt.core.model.Purpose;
 import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
 
@@ -32,10 +33,10 @@ public interface ConsentManagementListener {
 
     boolean isEnable();
 
-    void preAddPurpose(String purposeUuid, String purposeName, String tenantDomain)
+    void preAddPurpose(Purpose purpose, String tenantDomain)
             throws ConsentManagementException;
 
-    void postAddPurpose(String purposeUuid, String purposeName, String tenantDomain)
+    void postAddPurpose(Purpose purpose, String tenantDomain)
             throws ConsentManagementException;
 
     void preDeletePurpose(String purposeUuid, String tenantDomain)


### PR DESCRIPTION
## Purpose
This pull request updates how the `preAddPurpose` and `publishPreAddPurposeWithException` methods are called in the `PrivilegedConsentManagerImpl` class, specifically changing the identifier passed to these methods from the purpose's UUID to its ID (as a string). This ensures consistency in how purpose identifiers are handled during event publishing and listener notification.

**Purpose identifier handling:**

* Changed the argument passed to `preAddPurpose` and `publishPreAddPurposeWithException` from `purpose.getUuid()` to `String.valueOf(purpose.getId())`, ensuring the purpose ID is used instead of the UUID when notifying listeners and publishing events.

Related PR https://github.com/wso2/carbon-consent-management/pull/268

## Related issue
- https://github.com/wso2/product-is/issues/26859
