### PR TITLE
Add cache layer for consents

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/pom.xml
+++ b/components/org.wso2.carbon.consent.mgt.core/pom.xml
@@ -124,6 +124,7 @@
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.model; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.cache; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event.*; version="${carbon.identity.framework.imp.pkg.version.range}"

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/CacheBackedConsentManager.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/CacheBackedConsentManager.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeCache;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeCacheEntry;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeCacheKey;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeVersionCache;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeVersionCacheEntry;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeVersionCacheKey;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeVersionListCache;
+import org.wso2.carbon.consent.mgt.core.cache.PurposeVersionListCacheEntry;
+import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
+import org.wso2.carbon.consent.mgt.core.model.AddReceiptResponse;
+import org.wso2.carbon.consent.mgt.core.model.ConsentAuthorization;
+import org.wso2.carbon.consent.mgt.core.model.PIICategory;
+import org.wso2.carbon.consent.mgt.core.model.Purpose;
+import org.wso2.carbon.consent.mgt.core.model.PurposeCategory;
+import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
+import org.wso2.carbon.consent.mgt.core.model.Receipt;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptListResponse;
+import org.wso2.carbon.identity.core.model.ExpressionNode;
+
+import java.util.List;
+
+import static org.wso2.carbon.consent.mgt.core.util.ConsentUtils.getTenantDomainFromCarbonContext;
+
+/**
+ * Decorator that wraps a {@link ConsentManager} delegate and adds a caching layer.
+ * <p>
+ * Cache READ methods: check cache first, delegate on miss, populate cache with result.
+ * Cache INVALIDATION methods: call delegate first, then clear relevant cache entries.
+ * All other methods are forwarded directly to the delegate.
+ * <p>
+ * Cached data:
+ * <ul>
+ *   <li>{@link org.wso2.carbon.consent.mgt.core.cache.PurposeCache} — individual purposes by UUID</li>
+ *   <li>{@link PurposeVersionCache} — individual purpose versions by (purposeUuid, versionUuid)</li>
+ *   <li>{@link PurposeVersionListCache} — full version list per purpose by purposeUuid</li>
+ * </ul>
+ */
+public class CacheBackedConsentManager implements ConsentManager {
+
+    private static final Log LOG = LogFactory.getLog(CacheBackedConsentManager.class);
+
+    private final ConsentManager delegate;
+    private final PurposeCache purposeCache = PurposeCache.getInstance();
+    private final PurposeVersionCache purposeVersionCache = PurposeVersionCache.getInstance();
+    private final PurposeVersionListCache purposeVersionListCache = PurposeVersionListCache.getInstance();
+
+    public CacheBackedConsentManager(ConsentManager delegate) {
+
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<PurposeVersion> listPurposeVersions(String purposeUuid) throws ConsentManagementException {
+
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        PurposeCacheKey key = new PurposeCacheKey(purposeUuid);
+        PurposeVersionListCacheEntry cached = purposeVersionListCache.getValueFromCache(key, tenantDomain);
+        if (cached != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cache entry found for PurposeVersionList of purpose " + purposeUuid);
+            }
+            return cached.getVersions();
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Cache entry not found for PurposeVersionList of purpose " + purposeUuid
+                    + ". Fetching entry from DB");
+        }
+        List<PurposeVersion> versions = delegate.listPurposeVersions(purposeUuid);
+        if (versions != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Entry fetched from DB for PurposeVersionList of purpose " + purposeUuid
+                        + ". Updating cache");
+            }
+            purposeVersionListCache.addToCache(key, new PurposeVersionListCacheEntry(versions), tenantDomain);
+        }
+        return versions;
+    }
+
+    @Override
+    public PurposeVersion getPurposeVersion(String purposeUuid, String versionUuid) throws ConsentManagementException {
+
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        PurposeVersionCacheKey key = new PurposeVersionCacheKey(purposeUuid, versionUuid);
+        PurposeVersionCacheEntry cached = purposeVersionCache.getValueFromCache(key, tenantDomain);
+        if (cached != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cache entry found for PurposeVersion " + versionUuid + " of purpose " + purposeUuid);
+            }
+            return cached.getVersion();
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Cache entry not found for PurposeVersion " + versionUuid + " of purpose " + purposeUuid
+                    + ". Fetching entry from DB");
+        }
+        PurposeVersion version = delegate.getPurposeVersion(purposeUuid, versionUuid);
+        if (version != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Entry fetched from DB for PurposeVersion " + versionUuid + " of purpose " + purposeUuid
+                        + ". Updating cache");
+            }
+            purposeVersionCache.addToCache(key, new PurposeVersionCacheEntry(version), tenantDomain);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Entry for PurposeVersion " + versionUuid + " of purpose " + purposeUuid
+                        + " not found in cache or DB");
+            }
+        }
+        return version;
+    }
+
+    @Override
+    public Purpose addPurpose(Purpose purpose) throws ConsentManagementException {
+
+        return delegate.addPurpose(purpose);
+    }
+
+    @Override
+    public Purpose addPurposeWithUuid(Purpose purpose) throws ConsentManagementException {
+
+        return delegate.addPurposeWithUuid(purpose);
+    }
+
+    @Override
+    public void deletePurpose(int purposeId) throws ConsentManagementException {
+
+        delegate.deletePurpose(purposeId);
+    }
+
+    @Override
+    public void deletePurpose(String purposeUuid) throws ConsentManagementException {
+
+        delegate.deletePurpose(purposeUuid);
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing entry for Purpose " + purposeUuid + " of tenantDomain:" + tenantDomain
+                    + " from cache.");
+        }
+        PurposeCacheKey key = new PurposeCacheKey(purposeUuid);
+        purposeCache.clearCacheEntry(key, tenantDomain);
+        purposeVersionListCache.clearCacheEntry(key, tenantDomain);
+        purposeVersionCache.clear(tenantDomain);
+    }
+
+    @Override
+    public void deletePurposes(int tenantId) throws ConsentManagementException {
+
+        delegate.deletePurposes(tenantId);
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing all Purpose, PurposeVersion and PurposeVersionList cache entries of tenantDomain:"
+                    + tenantDomain + " from cache.");
+        }
+        purposeCache.clear(tenantDomain);
+        purposeVersionListCache.clear(tenantDomain);
+        purposeVersionCache.clear(tenantDomain);
+    }
+
+    @Override
+    public PurposeVersion addPurposeVersion(String purposeUuid, PurposeVersion purposeVersion, boolean setAsLatest)
+            throws ConsentManagementException {
+
+        PurposeVersion result = delegate.addPurposeVersion(purposeUuid, purposeVersion, setAsLatest);
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        PurposeCacheKey key = new PurposeCacheKey(purposeUuid);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing entry for PurposeVersionList of purpose " + purposeUuid + " of tenantDomain:"
+                    + tenantDomain + " from cache.");
+        }
+        purposeVersionListCache.clearCacheEntry(key, tenantDomain);
+        if (setAsLatest) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Removing entry for Purpose " + purposeUuid + " of tenantDomain:" + tenantDomain
+                        + " from cache after setting latest version.");
+            }
+            purposeCache.clearCacheEntry(key, tenantDomain);
+        }
+        return result;
+    }
+
+    @Override
+    public void deletePurposeVersion(String purposeUuid, String versionUuid) throws ConsentManagementException {
+
+        delegate.deletePurposeVersion(purposeUuid, versionUuid);
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing entry for PurposeVersion " + versionUuid + " of purpose " + purposeUuid
+                    + " of tenantDomain:" + tenantDomain + " from cache.");
+        }
+        purposeVersionCache.clearCacheEntry(new PurposeVersionCacheKey(purposeUuid, versionUuid), tenantDomain);
+        purposeVersionListCache.clearCacheEntry(new PurposeCacheKey(purposeUuid), tenantDomain);
+    }
+
+    @Override
+    public void setLatestPurposeVersion(String purposeUUID, String versionLabel) throws ConsentManagementException {
+
+        delegate.setLatestPurposeVersion(purposeUUID, versionLabel);
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing entry for Purpose " + purposeUUID + " of tenantDomain:" + tenantDomain
+                    + " from cache after updating latest version.");
+        }
+        purposeCache.clearCacheEntry(new PurposeCacheKey(purposeUUID), tenantDomain);
+    }
+
+    @Override
+    public List<Receipt> listReceipts(String subjectId, String serviceId, String state,
+                                      String purposeId, String purposeVersionId,
+                                      String after, String before, int limit)
+            throws ConsentManagementException {
+
+        return delegate.listReceipts(subjectId, serviceId, state, purposeId, purposeVersionId, after, before, limit);
+    }
+
+    @Override
+    public AddReceiptResponse addConsent(ReceiptInput receiptInput) throws ConsentManagementException {
+
+        return delegate.addConsent(receiptInput);
+    }
+
+    @Override
+    public void revokeReceipt(String receiptId) throws ConsentManagementException {
+
+        delegate.revokeReceipt(receiptId);
+    }
+
+    @Override
+    public void deleteReceipt(String receiptId) throws ConsentManagementException {
+
+        delegate.deleteReceipt(receiptId);
+    }
+
+    @Override
+    public void deleteReceipts(int tenantId) throws ConsentManagementException {
+
+        delegate.deleteReceipts(tenantId);
+    }
+
+    @Override
+    public Purpose getPurpose(int purposeId) throws ConsentManagementException {
+
+        return delegate.getPurpose(purposeId);
+    }
+
+    @Override
+    public Purpose getPurposeByName(String name, String group, String groupType) throws ConsentManagementException {
+
+        return delegate.getPurposeByName(name, group, groupType);
+    }
+
+    @Override
+    public Purpose getPurposeByUuid(String uuid) throws ConsentManagementException {
+
+        String tenantDomain = getTenantDomainFromCarbonContext();
+        PurposeCacheKey key = new PurposeCacheKey(uuid);
+        PurposeCacheEntry cached = purposeCache.getValueFromCache(key, tenantDomain);
+        if (cached != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cache entry found for Purpose " + uuid);
+            }
+            return cached.getPurpose();
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Cache entry not found for Purpose " + uuid + ". Fetching entry from DB");
+        }
+        Purpose purpose = delegate.getPurposeByUuid(uuid);
+        if (purpose != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Entry fetched from DB for Purpose " + uuid + ". Updating cache");
+            }
+            purposeCache.addToCache(key, new PurposeCacheEntry(purpose), tenantDomain);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Entry for Purpose " + uuid + " not found in cache or DB");
+            }
+        }
+        return purpose;
+    }
+
+    @Override
+    public List<Purpose> listPurposes(int limit, int offset) throws ConsentManagementException {
+
+        return delegate.listPurposes(limit, offset);
+    }
+
+    @Override
+    public List<Purpose> listPurposes(String group, String groupType, int limit, int offset)
+            throws ConsentManagementException {
+
+        return delegate.listPurposes(group, groupType, limit, offset);
+    }
+
+    @Override
+    public List<Purpose> listPurposes(List<ExpressionNode> expressionNodes, int limit)
+            throws ConsentManagementException {
+
+        return delegate.listPurposes(expressionNodes, limit);
+    }
+
+    @Override
+    public boolean isPurposeExists(String name, String group, String groupType) throws ConsentManagementException {
+
+        return delegate.isPurposeExists(name, group, groupType);
+    }
+
+    @Override
+    public PurposeCategory addPurposeCategory(PurposeCategory purposeCategory) throws ConsentManagementException {
+
+        return delegate.addPurposeCategory(purposeCategory);
+    }
+
+    @Override
+    public PurposeCategory getPurposeCategory(int purposeCategoryId) throws ConsentManagementException {
+
+        return delegate.getPurposeCategory(purposeCategoryId);
+    }
+
+    @Override
+    public PurposeCategory getPurposeCategoryByName(String name) throws ConsentManagementException {
+
+        return delegate.getPurposeCategoryByName(name);
+    }
+
+    @Override
+    public List<PurposeCategory> listPurposeCategories(int limit, int offset) throws ConsentManagementException {
+
+        return delegate.listPurposeCategories(limit, offset);
+    }
+
+    @Override
+    public void deletePurposeCategory(int purposeCategoryId) throws ConsentManagementException {
+
+        delegate.deletePurposeCategory(purposeCategoryId);
+    }
+
+    @Override
+    public void deletePurposeCategories(int tenantId) throws ConsentManagementException {
+
+        delegate.deletePurposeCategories(tenantId);
+    }
+
+    @Override
+    public boolean isPurposeCategoryExists(String name) throws ConsentManagementException {
+
+        return delegate.isPurposeCategoryExists(name);
+    }
+
+    @Override
+    public PIICategory addPIICategory(PIICategory piiCategory) throws ConsentManagementException {
+
+        return delegate.addPIICategory(piiCategory);
+    }
+
+    @Override
+    public PIICategory addPIICategoryWithUuid(PIICategory piiCategory) throws ConsentManagementException {
+
+        return delegate.addPIICategoryWithUuid(piiCategory);
+    }
+
+    @Override
+    public PIICategory getPIICategoryByName(String name) throws ConsentManagementException {
+
+        return delegate.getPIICategoryByName(name);
+    }
+
+    @Override
+    public PIICategory getPIICategory(int piiCategoryId) throws ConsentManagementException {
+
+        return delegate.getPIICategory(piiCategoryId);
+    }
+
+    @Override
+    public List<PIICategory> listPIICategories(int limit, int offset) throws ConsentManagementException {
+
+        return delegate.listPIICategories(limit, offset);
+    }
+
+    @Override
+    public List<PIICategory> listPIICategories(List<ExpressionNode> expressionNodes, int limit)
+            throws ConsentManagementException {
+
+        return delegate.listPIICategories(expressionNodes, limit);
+    }
+
+    @Override
+    public void deletePIICategory(int piiCategoryId) throws ConsentManagementException {
+
+        delegate.deletePIICategory(piiCategoryId);
+    }
+
+    @Override
+    public void deletePIICategory(String uuid) throws ConsentManagementException {
+
+        delegate.deletePIICategory(uuid);
+    }
+
+    @Override
+    public PIICategory getPIICategoryByUuid(String uuid) throws ConsentManagementException {
+
+        return delegate.getPIICategoryByUuid(uuid);
+    }
+
+    @Override
+    public void deletePIICategories(int tenantId) throws ConsentManagementException {
+
+        delegate.deletePIICategories(tenantId);
+    }
+
+    @Override
+    public boolean isPIICategoryExists(String name) throws ConsentManagementException {
+
+        return delegate.isPIICategoryExists(name);
+    }
+
+    @Override
+    public Receipt getReceipt(String receiptId) throws ConsentManagementException {
+
+        return delegate.getReceipt(receiptId);
+    }
+
+    @Override
+    public Receipt getReceiptWithExtendedSchema(String receiptId) throws ConsentManagementException {
+
+        return delegate.getReceiptWithExtendedSchema(receiptId);
+    }
+
+    @Override
+    public List<ReceiptListResponse> searchReceipts(int limit, int offset, String piiPrincipalId,
+                                                    String spTenantDomain, String service, String state)
+            throws ConsentManagementException {
+
+        return delegate.searchReceipts(limit, offset, piiPrincipalId, spTenantDomain, service, state);
+    }
+
+    @Override
+    public List<ReceiptListResponse> searchReceipts(int limit, int offset, String piiPrincipalId,
+                                                    String spTenantDomain, String service, String state,
+                                                    String principalTenantDomain)
+            throws ConsentManagementException {
+
+        return delegate.searchReceipts(limit, offset, piiPrincipalId, spTenantDomain, service, state,
+                principalTenantDomain);
+    }
+
+    @Override
+    public boolean isReceiptExist(String receiptId, String tenantAwareUsername, int tenantId)
+            throws ConsentManagementException {
+
+        return delegate.isReceiptExist(receiptId, tenantAwareUsername, tenantId);
+    }
+
+    @Override
+    public void authorizeConsent(String consentId, String userId, String authStatus)
+            throws ConsentManagementException {
+
+        delegate.authorizeConsent(consentId, userId, authStatus);
+    }
+
+    @Override
+    public List<ConsentAuthorization> getConsentAuthorizations(String consentId)
+            throws ConsentManagementException {
+
+        return delegate.getConsentAuthorizations(consentId);
+    }
+
+    @Override
+    public String validateConsentStatus(String consentId) throws ConsentManagementException {
+
+        return delegate.validateConsentStatus(consentId);
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -159,7 +159,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
     public PrivilegedConsentManagerImpl(ConsentManagerConfigurationHolder configHolder,
                                         List<ConsentMgtInterceptor> consentMgtInterceptors) {
 
-        consentManager = new ConsentManagerImpl(configHolder);
+        consentManager = new CacheBackedConsentManager(new ConsentManagerImpl(configHolder));
         this.consentMgtInterceptors = consentMgtInterceptors;
 
     }

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeCache.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeCache.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.cache.BaseCache;
+
+/**
+ * Cache for individual {@link org.wso2.carbon.consent.mgt.core.model.Purpose} objects,
+ * keyed by purpose UUID.
+ */
+public class PurposeCache extends BaseCache<PurposeCacheKey, PurposeCacheEntry> {
+
+    private static final Log log = LogFactory.getLog(PurposeCache.class);
+    private static final String CACHE_NAME = "ConsentPurposeCache";
+
+    private static final PurposeCache INSTANCE = new PurposeCache();
+
+    private PurposeCache() {
+
+        super(CACHE_NAME);
+    }
+
+    public static PurposeCache getInstance() {
+
+        return INSTANCE;
+    }
+
+    @Override
+    public void addToCache(PurposeCacheKey key, PurposeCacheEntry entry, String tenantDomain) {
+
+        try {
+            super.addToCache(key, entry, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping addToCache for PurposeCache.", e);
+            }
+        }
+    }
+
+    @Override
+    public PurposeCacheEntry getValueFromCache(PurposeCacheKey key, String tenantDomain) {
+
+        try {
+            return super.getValueFromCache(key, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping getValueFromCache for PurposeCache.", e);
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public void clearCacheEntry(PurposeCacheKey key, String tenantDomain) {
+
+        try {
+            super.clearCacheEntry(key, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping clearCacheEntry for PurposeCache.", e);
+            }
+        }
+    }
+
+    @Override
+    public void clear(String tenantDomain) {
+
+        try {
+            super.clear(tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping clear for PurposeCache.", e);
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeCacheEntry.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeCacheEntry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.wso2.carbon.consent.mgt.core.model.Purpose;
+import org.wso2.carbon.identity.core.cache.CacheEntry;
+
+/**
+ * Cache entry wrapping a single {@link Purpose}.
+ */
+public class PurposeCacheEntry extends CacheEntry {
+
+    private static final long serialVersionUID = 8123047261948302756L;
+
+    private final Purpose purpose;
+
+    public PurposeCacheEntry(Purpose purpose) {
+
+        this.purpose = purpose;
+    }
+
+    public Purpose getPurpose() {
+
+        return purpose;
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeCacheKey.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeCacheKey.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.wso2.carbon.identity.core.cache.CacheKey;
+
+import java.util.Objects;
+
+/**
+ * Cache key for a consent purpose, identified by its UUID.
+ * Used by {@link PurposeCache}.
+ */
+public class PurposeCacheKey extends CacheKey {
+
+    private static final long serialVersionUID = 4812736401948302751L;
+
+    private final String purposeUuid;
+
+    public PurposeCacheKey(String purposeUuid) {
+
+        this.purposeUuid = purposeUuid;
+    }
+
+    public String getPurposeUuid() {
+
+        return purposeUuid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PurposeCacheKey)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        PurposeCacheKey that = (PurposeCacheKey) o;
+        return Objects.equals(purposeUuid, that.purposeUuid);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(super.hashCode(), purposeUuid);
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionCache.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionCache.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.cache.BaseCache;
+
+/**
+ * Cache for individual {@link org.wso2.carbon.consent.mgt.core.model.PurposeVersion} objects,
+ * keyed by (purposeUuid, versionUuid).
+ */
+public class PurposeVersionCache extends BaseCache<PurposeVersionCacheKey, PurposeVersionCacheEntry> {
+
+    private static final Log log = LogFactory.getLog(PurposeVersionCache.class);
+    private static final String CACHE_NAME = "ConsentPurposeVersionCache";
+
+    private static final PurposeVersionCache INSTANCE = new PurposeVersionCache();
+
+    private PurposeVersionCache() {
+
+        super(CACHE_NAME);
+    }
+
+    public static PurposeVersionCache getInstance() {
+
+        return INSTANCE;
+    }
+
+    @Override
+    public void addToCache(PurposeVersionCacheKey key, PurposeVersionCacheEntry entry, String tenantDomain) {
+
+        try {
+            super.addToCache(key, entry, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping addToCache for PurposeVersionCache.", e);
+            }
+        }
+    }
+
+    @Override
+    public PurposeVersionCacheEntry getValueFromCache(PurposeVersionCacheKey key, String tenantDomain) {
+
+        try {
+            return super.getValueFromCache(key, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping getValueFromCache for PurposeVersionCache.", e);
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public void clearCacheEntry(PurposeVersionCacheKey key, String tenantDomain) {
+
+        try {
+            super.clearCacheEntry(key, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping clearCacheEntry for PurposeVersionCache.", e);
+            }
+        }
+    }
+
+    @Override
+    public void clear(String tenantDomain) {
+
+        try {
+            super.clear(tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping clear for PurposeVersionCache.", e);
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionCacheEntry.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionCacheEntry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
+import org.wso2.carbon.identity.core.cache.CacheEntry;
+
+/**
+ * Cache entry wrapping a single {@link PurposeVersion}.
+ */
+public class PurposeVersionCacheEntry extends CacheEntry {
+
+    private static final long serialVersionUID = 5930218467021947631L;
+
+    private final PurposeVersion version;
+
+    public PurposeVersionCacheEntry(PurposeVersion version) {
+
+        this.version = version;
+    }
+
+    public PurposeVersion getVersion() {
+
+        return version;
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionCacheKey.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionCacheKey.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.wso2.carbon.identity.core.cache.CacheKey;
+
+import java.util.Objects;
+
+/**
+ * Cache key for a specific {@link org.wso2.carbon.consent.mgt.core.model.PurposeVersion},
+ * identified by the parent purpose UUID and the version UUID.
+ */
+public class PurposeVersionCacheKey extends CacheKey {
+
+    private static final long serialVersionUID = -3047265801734920183L;
+
+    private final String purposeUuid;
+    private final String versionUuid;
+
+    public PurposeVersionCacheKey(String purposeUuid, String versionUuid) {
+
+        this.purposeUuid = purposeUuid;
+        this.versionUuid = versionUuid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PurposeVersionCacheKey)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        PurposeVersionCacheKey that = (PurposeVersionCacheKey) o;
+        return Objects.equals(purposeUuid, that.purposeUuid)
+                && Objects.equals(versionUuid, that.versionUuid);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(super.hashCode(), purposeUuid, versionUuid);
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionListCache.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionListCache.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.cache.BaseCache;
+
+/**
+ * Cache for the list of {@link org.wso2.carbon.consent.mgt.core.model.PurposeVersion} objects
+ * belonging to a purpose, keyed by purpose UUID via {@link PurposeCacheKey}.
+ */
+public class PurposeVersionListCache extends BaseCache<PurposeCacheKey, PurposeVersionListCacheEntry> {
+
+    private static final Log log = LogFactory.getLog(PurposeVersionListCache.class);
+    private static final String CACHE_NAME = "ConsentPurposeVersionListCache";
+
+    private static final PurposeVersionListCache INSTANCE = new PurposeVersionListCache();
+
+    private PurposeVersionListCache() {
+
+        super(CACHE_NAME);
+    }
+
+    public static PurposeVersionListCache getInstance() {
+
+        return INSTANCE;
+    }
+
+    @Override
+    public void addToCache(PurposeCacheKey key, PurposeVersionListCacheEntry entry, String tenantDomain) {
+
+        try {
+            super.addToCache(key, entry, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping addToCache for PurposeVersionListCache.", e);
+            }
+        }
+    }
+
+    @Override
+    public PurposeVersionListCacheEntry getValueFromCache(PurposeCacheKey key, String tenantDomain) {
+
+        try {
+            return super.getValueFromCache(key, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping getValueFromCache for PurposeVersionListCache.",
+                        e);
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public void clearCacheEntry(PurposeCacheKey key, String tenantDomain) {
+
+        try {
+            super.clearCacheEntry(key, tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping clearCacheEntry for PurposeVersionListCache.",
+                        e);
+            }
+        }
+    }
+
+    @Override
+    public void clear(String tenantDomain) {
+
+        try {
+            super.clear(tenantDomain);
+        } catch (RuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache infrastructure not available, skipping clear for PurposeVersionListCache.", e);
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionListCacheEntry.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/cache/PurposeVersionListCacheEntry.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.consent.mgt.core.cache;
+
+import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
+import org.wso2.carbon.identity.core.cache.CacheEntry;
+
+import java.util.List;
+
+/**
+ * Cache entry wrapping the full list of {@link PurposeVersion} objects for a purpose.
+ * Used by {@link PurposeVersionListCache}.
+ */
+public class PurposeVersionListCacheEntry extends CacheEntry {
+
+    private static final long serialVersionUID = 7341829561302847312L;
+
+    private final List<PurposeVersion> versions;
+
+    public PurposeVersionListCacheEntry(List<PurposeVersion> versions) {
+
+        this.versions = versions;
+    }
+
+    public List<PurposeVersion> getVersions() {
+
+        return versions;
+    }
+}

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/ConsentPurpose.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/ConsentPurpose.java
@@ -16,10 +16,13 @@
 
 package org.wso2.carbon.consent.mgt.core.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ConsentPurpose {
+public class ConsentPurpose implements Serializable {
+
+    private static final long serialVersionUID = 2522126638714413314L;
 
     private String purpose;
     private int purposeId;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PIICategory.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PIICategory.java
@@ -16,10 +16,14 @@
 
 package org.wso2.carbon.consent.mgt.core.model;
 
+import java.io.Serializable;
+
 /**
  * Represents a PII (Personally Identifiable Information) category. Referred to as "Element" in the V2 API.
  */
-public class PIICategory {
+public class PIICategory implements Serializable {
+
+    private static final long serialVersionUID = 4325917231838602359L;
 
     private Integer id;
     private String name;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PIICategoryValidity.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PIICategoryValidity.java
@@ -16,12 +16,16 @@
 
 package org.wso2.carbon.consent.mgt.core.model;
 
+import java.io.Serializable;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
  * The model representing a PII Category Validity model.
  */
-public class PIICategoryValidity {
+public class PIICategoryValidity implements Serializable {
+
+    private static final long serialVersionUID = 7464635563682220786L;
 
     @SerializedName("piiCategoryId")
     private Integer id;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/Purpose.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/Purpose.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.consent.mgt.core.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,9 @@ import java.util.Map;
 /**
  * The model representing a purpose of a given consent.
  */
-public class Purpose {
+public class Purpose implements Serializable {
+
+    private static final long serialVersionUID = -1691326925192849025L;
 
     private Integer id;
     private String name;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PurposePIICategory.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PurposePIICategory.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.consent.mgt.core.model;
  */
 public class PurposePIICategory extends PIICategory {
 
+    private static final long serialVersionUID = -2090780556750076831L;
+
     private Boolean mandatory;
 
     public PurposePIICategory(PIICategory piiCategory, Boolean mandatory) {

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PurposeVersion.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/PurposeVersion.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.consent.mgt.core.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +26,9 @@ import java.util.Map;
 /**
  * The model representing a version of a consent purpose.
  */
-public class PurposeVersion {
+public class PurposeVersion implements Serializable {
+
+    private static final long serialVersionUID = -1358718197368484399L;
 
     private int purposeId;
     private String version;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/Receipt.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/Receipt.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.consent.mgt.core.model;
 
+import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,9 @@ import java.util.Map;
 /**
  * The model representing a a consent receipt.
  */
-public class Receipt {
+public class Receipt implements Serializable {
+
+    private static final long serialVersionUID = -6531789894201998360L;
 
     private String consentReceiptId;
     private String version;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/ReceiptService.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/ReceiptService.java
@@ -16,9 +16,12 @@
 
 package org.wso2.carbon.consent.mgt.core.model;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ReceiptService {
+public class ReceiptService implements Serializable {
+
+    private static final long serialVersionUID = 165545803519005314L;
 
     private String service;
     private String spDisplayName;

--- a/components/org.wso2.carbon.consent.mgt.core/src/test/resources/conf/carbon.xml
+++ b/components/org.wso2.carbon.consent.mgt.core/src/test/resources/conf/carbon.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+    <Name>WSO2 Identity Server</Name>
+    <ServerKey>IS</ServerKey>
+    <Version>5.3.0</Version>
+    <HostName>localhost</HostName>
+    <MgtHostName>localhost</MgtHostName>
+    <ServerURL>local:/${carbon.context}/services/</ServerURL>
+
+    <ServerRoles>
+        <Role>IdentityServer</Role>
+    </ServerRoles>
+
+    <Package>org.wso2.carbon</Package>
+    <WebContextRoot>/</WebContextRoot>
+    <ItemsPerPage>15</ItemsPerPage>
+
+    <Ports>
+        <Offset>0</Offset>
+        <JMX>
+            <RMIRegistryPort>9999</RMIRegistryPort>
+            <RMIServerPort>11111</RMIServerPort>
+        </JMX>
+    </Ports>
+
+    <JNDI>
+        <DefaultInitialContextFactory>org.wso2.carbon.tomcat.jndi.CarbonJavaURLContextFactory</DefaultInitialContextFactory>
+        <Restrictions>
+            <AllTenants>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>java</Scheme>
+                    </UrlContext>
+                </UrlContexts>
+            </AllTenants>
+        </Restrictions>
+    </JNDI>
+
+    <IsCloudDeployment>false</IsCloudDeployment>
+    <EnableMetering>false</EnableMetering>
+    <MaxThreadExecutionTime>600</MaxThreadExecutionTime>
+
+    <GhostDeployment>
+        <Enabled>false</Enabled>
+    </GhostDeployment>
+
+    <Tenant>
+        <LoadingPolicy>
+            <LazyLoading>
+                <IdleTime>30</IdleTime>
+            </LazyLoading>
+        </LoadingPolicy>
+    </Tenant>
+
+    <Cache>
+        <DefaultCacheTimeout>15</DefaultCacheTimeout>
+    </Cache>
+
+    <Security>
+        <KeyStore>
+            <Location>${carbon.home}/repository/resources/security/wso2carbon.jks</Location>
+            <Type>JKS</Type>
+            <Password>wso2carbon</Password>
+            <KeyAlias>wso2carbon</KeyAlias>
+            <KeyPassword>wso2carbon</KeyPassword>
+        </KeyStore>
+        <TrustStore>
+            <Location>${carbon.home}/repository/resources/security/client-truststore.jks</Location>
+            <Type>JKS</Type>
+            <Password>wso2carbon</Password>
+        </TrustStore>
+        <NetworkAuthenticatorConfig>
+        </NetworkAuthenticatorConfig>
+        <TomcatRealm>UserManager</TomcatRealm>
+        <DisableTokenStore>false</DisableTokenStore>
+    </Security>
+
+    <WorkDirectory>${carbon.home}/tmp/work</WorkDirectory>
+
+    <HouseKeeping>
+        <AutoStart>true</AutoStart>
+        <Interval>10</Interval>
+        <MaxTempFileLifetime>30</MaxTempFileLifetime>
+    </HouseKeeping>
+
+    <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
+
+</Server>


### PR DESCRIPTION
## Purpose
This pull request introduces a caching layer for consent data and receipts in the consent management core module, aiming to improve performance and scalability by reducing database lookups for frequently accessed consent information. It adds new cache classes and keys, updates the consent manager instantiation to use the cache-backed implementation, and ensures that relevant model classes are serializable for cache storage.

**Caching Infrastructure:**

* Introduced `ConsentDataCache` and `ConsentReceiptCache` classes along with their corresponding key and entry classes to cache consent purposes, versions, and user consent receipts. These caches handle cache infrastructure failures gracefully and are implemented as singletons. (`ConsentDataCache.java` [[1]](diffhunk://#diff-90b6c9f341b0cc584cd810d797e9ee85d84c2424da0fbc0e8b5a01ba3a4c0c1fR1-R94) `ConsentDataCacheKey.java` [[2]](diffhunk://#diff-278a21990e2e30c357b80bf22f676093d868617e94b474dfc6d1c022bd11f9afR1-R86) `ConsentDataCacheEntry.java` [[3]](diffhunk://#diff-053aefb12d5ad0919a19257f8b5e8fe5db929f0d1ec7d8e59713a739d72698f4R1-R44) `ConsentReceiptCache.java` [[4]](diffhunk://#diff-b1f98aa3cbc4bdab64fec62b1f14d92b2857a581f87109a42fd4d3a95e77cf2bR1-R82) `ConsentReceiptCacheKey.java` [[5]](diffhunk://#diff-cbf2a22ec7faed225a80754fd9be5bc639b4c0e56c9de3c76670061e88b7a0efR1-R73) `ConsentReceiptCacheEntry.java` [[6]](diffhunk://#diff-c2e4ce197d15f60fd4b1ce0248433be803f0773df9b668e7e651b1977f14cc11R1-R44)

**Consent Manager Integration:**

* Updated `PrivilegedConsentManagerImpl` to use the new `CacheBackedConsentManager`, enabling the use of the newly introduced caches for consent operations. (`PrivilegedConsentManagerImpl.java` [components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.javaL162-R162](diffhunk://#diff-294ccc62cb5ae96087853e3ade1b442f6e428b226e5cd27354334e7c5c034e4aL162-R162))
* Added a protected getter for `realmService` in `ConsentManagerImpl` to facilitate access from cache-backed implementations. (`ConsentManagerImpl.java` [components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.javaR187-R191](diffhunk://#diff-4a263d219438b44627b6304ebd3317a28fb49c021466c7b12c3fdb46d9439861R187-R191))

**Model Serialization:**

* Made all core consent-related model classes (`Purpose`, `PurposeVersion`, `ConsentPurpose`, `PIICategory`, `PIICategoryValidity`, `Receipt`, `ReceiptService`, and `PurposePIICategory`) implement `Serializable` and added `serialVersionUID` to ensure compatibility with Java serialization used by the caches. (`Purpose.java` [[1]](diffhunk://#diff-2ece2ddd0b96ffdc3e05ceeb80cb5d3b9ab6ff6a8fa6483fb6f6b30816ea00f2R19-R29) `PurposeVersion.java` [[2]](diffhunk://#diff-3f91e110a15f65728ad8e25f8d3e4b6fa9f0bb9ce7a9c0714b1790c223dee085R21-R31) `ConsentPurpose.java` [[3]](diffhunk://#diff-33fe1aa875f5dd7efa5467bd10f594170461ea2ed95c61973073377bfdbeb4beR19-R25) `PIICategory.java` [[4]](diffhunk://#diff-30b056de16d80e2d0c9b5840cba68c5009cd0d63f6073abd2ed3477475d98888R19-R26) `PIICategoryValidity.java` [[5]](diffhunk://#diff-6377d210200dc01e6231b8d91649862f219c0616d3c31e072cac21c83794d557R19-R28) `Receipt.java` [[6]](diffhunk://#diff-b22edcf4d2f2d85e765655e4192cc10ba5e6e29a7c9bbdaf11569d40ac8f7f38R19-R29) `ReceiptService.java` [[7]](diffhunk://#diff-f241fb71eaa4d510fc270a98256fa4b832da8bc1a3b9dd4c5f0d70c5327c6406R19-R24) `PurposePIICategory.java` [[8]](diffhunk://#diff-cbe26e9a3e34ab4dce0de092b0a212a87ad3c23950092341669c0981116e1022R24-R25)

**Dependency and Export Updates:**

* Updated the OSGi export package list in `pom.xml` to include the new `org.wso2.carbon.identity.core.cache` package, ensuring the cache classes are available to consumers. (`pom.xml` [components/org.wso2.carbon.consent.mgt.core/pom.xmlR127](diffhunk://#diff-bad66fa06b1a2c054e79e322d63e17e82f8a88ac50ac5ec1a0e7936c1621087cR127))

## Goals
Since most of the consent related functionalities are used in login and registration flows, it is better to have a caching layer for consents.