### PR TITLE
Revoke existing consents when accepting new consents

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -78,6 +78,7 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMe
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_AT_LEAST_ONE_PURPOSE_REQUIRED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_AT_LEAST_ONE_SERVICE_REQUIRED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CANNOT_DELETE_LATEST_PURPOSE_VERSION;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_MULTIPLE_PURPOSES_NOT_ALLOWED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_SUBJECT_MISMATCH;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_TYPE_MANDATORY;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_ELEMENT_UUID_NOT_FOUND;
@@ -722,6 +723,14 @@ public class ConsentManagerImpl implements ConsentManager {
                     : receiptInput.getPiiPrincipalId().equalsIgnoreCase(currentUser);
             if (!subjectMatchesCaller && !hasAuthorizations) {
                 throw handleClientException(ERROR_CODE_CONSENT_SUBJECT_MISMATCH, receiptInput.getPiiPrincipalId());
+            }
+            boolean isRejected = REJECTED_STATE.equals(receiptInput.getState());
+            if (!isRejected) {
+                for (ReceiptServiceInput svc : receiptInput.getServices()) {
+                    if (svc.getPurposes() != null && svc.getPurposes().size() > 1) {
+                        throw handleClientException(ERROR_CODE_CONSENT_MULTIPLE_PURPOSES_NOT_ALLOWED, null);
+                    }
+                }
             }
             List<ConsentAuthorization> authorizationsList = new ArrayList<>();
             if (authorizations != null && !authorizations.isEmpty()) {

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/ConsentConstants.java
@@ -270,7 +270,9 @@ public class ConsentConstants {
         ERROR_CODE_EVENT_PUBLISHING("CM_00121", "Error while publishing event: %s"),
         ERROR_CODE_INVALID_AUTHORIZATION_STATUS("CM_00122",
                 "Invalid authorization status: '%s'. Must be one of: APPROVED, REJECTED, REVOKED."),
-        ERROR_CODE_INVALID_CURSOR_TOKEN("CM_00123", "Invalid cursor token: %s.");
+        ERROR_CODE_INVALID_CURSOR_TOKEN("CM_00123", "Invalid cursor token: %s."),
+        ERROR_CODE_CONSENT_MULTIPLE_PURPOSES_NOT_ALLOWED("CM_00124",
+                "Only one purpose is allowed per consent unless the state is REJECTED.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/SQLConstants.java
@@ -371,7 +371,7 @@ public class SQLConstants {
             "AND CONSENT_RECEIPT_ID IN (" +
             "    SELECT rsa.CONSENT_RECEIPT_ID FROM CM_RECEIPT_SP_ASSOC rsa " +
             "    INNER JOIN CM_SP_PURPOSE_ASSOC spa ON rsa.ID = spa.RECEIPT_SP_ASSOC " +
-            "    WHERE rsa.SP_NAME = ? AND spa.PURPOSE_ID = ?" +
+            "    WHERE rsa.SP_NAME = ? AND rsa.SP_TENANT_ID = ? AND spa.PURPOSE_ID = ?" +
             ")";
 
     public static final String GET_PURPOSE_PII_CAT_SQL = "SELECT CM_PII_CATEGORY_ID, IS_MANDATORY FROM " +

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/SQLConstants.java
@@ -365,6 +365,15 @@ public class SQLConstants {
 
     public static final String REVOKE_RECEIPT_SQL = "UPDATE CM_RECEIPT SET STATE = ? WHERE CONSENT_RECEIPT_ID = ?";
 
+    public static final String REVOKE_ACTIVE_RECEIPTS_BY_SUBJECT_SERVICE_PURPOSE_SQL =
+            "UPDATE CM_RECEIPT SET STATE = ? " +
+            "WHERE PII_PRINCIPAL_ID = ? AND STATE IN ('ACTIVE', 'PENDING') AND PRINCIPAL_TENANT_ID = ? " +
+            "AND CONSENT_RECEIPT_ID IN (" +
+            "    SELECT rsa.CONSENT_RECEIPT_ID FROM CM_RECEIPT_SP_ASSOC rsa " +
+            "    INNER JOIN CM_SP_PURPOSE_ASSOC spa ON rsa.ID = spa.RECEIPT_SP_ASSOC " +
+            "    WHERE rsa.SP_NAME = ? AND spa.PURPOSE_ID = ?" +
+            ")";
+
     public static final String GET_PURPOSE_PII_CAT_SQL = "SELECT CM_PII_CATEGORY_ID, IS_MANDATORY FROM " +
                                                          "CM_PURPOSE_PII_CAT_ASSOC WHERE PURPOSE_ID = ?";
     public static final String GET_ACTIVE_RECEIPTS_SQL = "SELECT R.CONSENT_RECEIPT_ID FROM CM_RECEIPT R INNER JOIN " +

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImpl.java
@@ -1177,7 +1177,8 @@ public class ReceiptDAOImpl implements ReceiptDAO {
             preparedStatement.setString(2, receiptInput.getPiiPrincipalId());
             preparedStatement.setInt(3, receiptInput.getTenantId());
             preparedStatement.setString(4, svc.getService());
-            preparedStatement.setInt(5, purposeInput.getPurposeId());
+            preparedStatement.setInt(5, svc.getTenantId());
+            preparedStatement.setInt(6, purposeInput.getPurposeId());
         });
     }
 

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImpl.java
@@ -85,6 +85,7 @@ import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.INSERT_SP_P
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.INSERT_SP_PURPOSE_TO_PURPOSE_CAT_ASSOC_SQL;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.INSERT_SP_TO_PURPOSE_ASSOC_SQL;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.INSERT_SP_TO_PURPOSE_ASSOC_WITH_VERSION_SQL;
+import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.REVOKE_ACTIVE_RECEIPTS_BY_SUBJECT_SERVICE_PURPOSE_SQL;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.REVOKE_RECEIPT_SQL;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.SEARCH_RECEIPT_SQL;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.SEARCH_RECEIPT_SQL_DB2;
@@ -148,9 +149,7 @@ public class ReceiptDAOImpl implements ReceiptDAO {
         JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
         try {
             jdbcTemplate.withTransaction(template -> {
-                if (!receiptInput.isAllowMultipleActiveReceipts()) {
-                    revokeActiveReceipts(receiptInput, template);
-                }
+                revokeActiveReceipts(receiptInput, template);
                 addReceiptInfo(receiptInput);
 
                 receiptInput.getServices().forEach(rethrowConsumer(receiptServiceInput -> {
@@ -1131,14 +1130,13 @@ public class ReceiptDAOImpl implements ReceiptDAO {
         JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
         try {
             jdbcTemplate.withTransaction(template -> {
-                if (!receiptInput.isAllowMultipleActiveReceipts()) {
-                    revokeActiveReceipts(receiptInput, template);
-                }
                 addReceiptInfo(receiptInput);
 
                 receiptInput.getServices().forEach(rethrowConsumer(receiptServiceInput -> {
                     int receiptToSPAssocId = addReceiptSPAssociation(receiptInput.getConsentReceiptId(), receiptServiceInput);
                     receiptServiceInput.getPurposes().forEach(rethrowConsumer(receiptPurposeInput -> {
+                        // Revoke existing ACTIVE/PENDING consents for the same subject, service, and purpose.
+                        revokeActiveReceipts(receiptInput, receiptServiceInput, receiptPurposeInput, template);
                         int spToPurposeAssocId = addSpToPurposeAssociation(receiptToSPAssocId, receiptPurposeInput);
 
                         receiptPurposeInput.getPurposeCategoryId().forEach(rethrowConsumer(id ->
@@ -1168,6 +1166,19 @@ public class ReceiptDAOImpl implements ReceiptDAO {
             throw ConsentUtils.handleServerException(ErrorMessages.ERROR_CODE_ADD_CONSENT_RECEIPT,
                     receiptInput.getPiiPrincipalId(), e);
         }
+    }
+
+    private void revokeActiveReceipts(ReceiptInput receiptInput, ReceiptServiceInput svc,
+                                       ReceiptPurposeInput purposeInput, Template template)
+            throws DataAccessException {
+
+        template.executeUpdate(REVOKE_ACTIVE_RECEIPTS_BY_SUBJECT_SERVICE_PURPOSE_SQL, preparedStatement -> {
+            preparedStatement.setString(1, REVOKE_STATE);
+            preparedStatement.setString(2, receiptInput.getPiiPrincipalId());
+            preparedStatement.setInt(3, receiptInput.getTenantId());
+            preparedStatement.setString(4, svc.getService());
+            preparedStatement.setInt(5, purposeInput.getPurposeId());
+        });
     }
 
     @Override

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/ReceiptInput.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/model/ReceiptInput.java
@@ -40,8 +40,6 @@ public class ReceiptInput {
     private String piiControllerInfo;
     private Timestamp expiryTime;
     private List<String> authorizations;
-    private boolean allowMultipleActiveReceipts = false;
-
     public String getConsentReceiptId() {
 
         return consentReceiptId;
@@ -192,13 +190,4 @@ public class ReceiptInput {
         this.authorizations = authorizations;
     }
 
-    public boolean isAllowMultipleActiveReceipts() {
-
-        return allowMultipleActiveReceipts;
-    }
-
-    public void setAllowMultipleActiveReceipts(boolean allowMultipleActiveReceipts) {
-
-        this.allowMultipleActiveReceipts = allowMultipleActiveReceipts;
-    }
 }

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/util/ConsentReceiptUtils.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/util/ConsentReceiptUtils.java
@@ -83,7 +83,7 @@ public class ConsentReceiptUtils {
      */
     public static ReceiptInput buildReceiptInput(String language, String subjectId, String tenantDomain,
                                                  Timestamp expiryTime, boolean rejected, List<String> authorizationUserIds,
-                                                 Map<String, String> properties,String serviceId, 
+                                                 Map<String, String> properties, String serviceId,
                                                  List<PurposePIICategoryBinding> purposeBindings,
                                                  ConsentManager consentManager)
             throws ConsentManagementException {
@@ -93,7 +93,6 @@ public class ConsentReceiptUtils {
         receiptInput.setJurisdiction(StringUtils.EMPTY);
         receiptInput.setPolicyUrl(StringUtils.EMPTY);
         receiptInput.setCollectionMethod(DEFAULT_COLLECTION_METHOD);
-        receiptInput.setAllowMultipleActiveReceipts(true);
         receiptInput.setLanguage(language);
         receiptInput.setPiiPrincipalId(subjectId);
         receiptInput.setTenantDomain(tenantDomain);

--- a/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImplTest.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImplTest.java
@@ -597,7 +597,7 @@ public class ReceiptDAOImplTest {
     }
 
     @Test
-    public void testAddReceipt_secondReceipt_revokesFirst_whenFlagNotSet() throws Exception {
+    public void testAddReceipt_secondReceipt_revokesFirst() throws Exception {
 
         DataSource dataSource = mock(DataSource.class);
 
@@ -618,38 +618,6 @@ public class ReceiptDAOImplTest {
             Receipt first = receiptDAO.getReceipt(receiptInputs.get(0).getConsentReceiptId());
             Assert.assertEquals(first.getState(), ConsentConstants.REVOKE_STATE,
                     "First receipt must be revoked when a second consent is added for the same user+service.");
-        }
-    }
-
-    @Test
-    public void testAddReceipt_doesNotRevokeExisting_whenFlagSet() throws Exception {
-
-        DataSource dataSource = mock(DataSource.class);
-
-        try (MockedStatic<ConsentManagerComponentDataHolder> dataHolderMockedStatic = mockComponentDataHolder(dataSource);
-             Connection connection = getConnection()) {
-
-            Connection spy = spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-
-            ReceiptDAO receiptDAO = new ReceiptDAOImpl();
-
-            ReceiptInput first = cloneReceiptInput(receiptInputs.get(0));
-            first.setAllowMultipleActiveReceipts(true);
-            receiptDAO.addReceipt(first);
-
-            ReceiptInput second = cloneReceiptInput(receiptInputs.get(0));
-            second.setConsentReceiptId(UUID.randomUUID().toString());
-            second.setAllowMultipleActiveReceipts(true);
-            receiptDAO.addReceipt(second);
-
-            Receipt firstReceipt = receiptDAO.getReceipt(first.getConsentReceiptId());
-            Assert.assertEquals(firstReceipt.getState(), ConsentConstants.ACTIVE_STATE,
-                    "First receipt must remain ACTIVE when allowMultipleActiveReceipts is true.");
-
-            Receipt secondReceipt = receiptDAO.getReceipt(second.getConsentReceiptId());
-            Assert.assertEquals(secondReceipt.getState(), ConsentConstants.ACTIVE_STATE,
-                    "Second receipt must also be ACTIVE when allowMultipleActiveReceipts is true.");
         }
     }
 

--- a/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/util/ConsentReceiptUtilsTest.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/util/ConsentReceiptUtilsTest.java
@@ -95,7 +95,6 @@ public class ConsentReceiptUtilsTest {
         Assert.assertEquals(result.getTenantDomain(), TENANT_DOMAIN);
         Assert.assertEquals(result.getVersion(), ConsentConstants.API_VERSION);
         Assert.assertEquals(result.getCollectionMethod(), "V2");
-        Assert.assertTrue(result.isAllowMultipleActiveReceipts());
         Assert.assertEquals(result.getLanguage(), LANG);
 
         Assert.assertEquals(result.getServices().size(), 1);


### PR DESCRIPTION
### Purpose

Related issue https://github.com/wso2/product-is/issues/26859

- For V2 API, when a new consent record is created per application per purpose per user, then the existing records are revoekd.
- To facilitate this, we are allowing a consent record to have a single purpose