### PR TITLE
Improvements for consent management service

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -74,7 +74,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -2027,20 +2026,19 @@ public class ConsentManagerImpl implements ConsentManager {
                                     throw new RuntimeException(e);
                                 }
                             },
-                            new MergeAllAggregationStrategy<List<Purpose>>((accumulated, fromParent) -> {
-                                Map<String, Purpose> byUuid = new LinkedHashMap<>();
-                                for (Purpose p : accumulated) {
-                                    byUuid.put(p.getUuid(), p);
-                                }
-                                for (Purpose p : fromParent) {
-                                    byUuid.putIfAbsent(p.getUuid(), p);
-                                }
-                                return new ArrayList<>(byUuid.values());
+                            new MergeAllAggregationStrategy<>((accumulated, fromParent) -> {
+                                // Purpose UUIDs are unique across the server
+                                List<Purpose> combined = new ArrayList<>(accumulated);
+                                combined.addAll(fromParent);
+                                return combined;
                             }));
             if (merged == null) {
                 return new ArrayList<>();
             }
             merged.sort(Comparator.comparingInt(p -> p.getId() != null ? p.getId() : 0));
+            if (limit > 0 && merged.size() > limit) {
+                return merged.subList(0, limit);
+            }
             return merged;
         } catch (OrgResourceHierarchyTraverseException e) {
             throw handleServerException(ERROR_CODE_ORGANIZATION_TRAVERSAL, getTenantDomainFromCarbonContext(), e);

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -359,9 +359,6 @@ public class ConsentManagerImpl implements ConsentManager {
     public void deletePurpose(String uuid) throws ConsentManagementException {
 
         Purpose purpose = getPurposeByUuid(uuid);
-        if (purpose.getTenantId() != getTenantIdFromCarbonContext()) {
-            throw handleClientException(ERROR_CODE_PURPOSE_UUID_NOT_FOUND, uuid);
-        }
         List<PurposeVersion> versions = listPurposeVersions(uuid);
         if (isEmpty(versions)) {
             deletePurpose(purpose.getId());
@@ -674,9 +671,6 @@ public class ConsentManagerImpl implements ConsentManager {
     public void deletePIICategory(String uuid) throws ConsentManagementException {
 
         PIICategory category = getPIICategoryByUuid(uuid);
-        if (category.getTenantId() != getTenantIdFromCarbonContext()) {
-            throw handleClientException(ERROR_CODE_ELEMENT_UUID_NOT_FOUND, uuid);
-        }
         deletePIICategory(category.getId());
     }
 
@@ -968,11 +962,8 @@ public class ConsentManagerImpl implements ConsentManager {
             throw handleClientException(ERROR_CODE_PURPOSE_VERSION_REQUIRED, null);
         }
 
-        // Fetch purpose by UUID and verify it belongs to the current tenant.
+        // Fetch purpose by UUID.
         Purpose purpose = getPurposeByUuid(purposeUuid);
-        if (purpose.getTenantId() != getTenantIdFromCarbonContext()) {
-            throw handleClientException(ERROR_CODE_PURPOSE_UUID_NOT_FOUND, purposeUuid);
-        }
 
         // Check for duplicate version label.
         // Note: purposes created via the V1 API may have no versions. Adding a version to such a purpose works,
@@ -1065,9 +1056,6 @@ public class ConsentManagerImpl implements ConsentManager {
 
         // Prevent deletion of the version currently marked as latest (would violate FK constraint).
         Purpose purpose = getPurposeByUuid(purposeUuid);
-        if (purpose.getTenantId() != getTenantIdFromCarbonContext()) {
-            throw handleClientException(ERROR_CODE_PURPOSE_UUID_NOT_FOUND, purposeUuid);
-        }
         if (versionUuid.equals(purpose.getLatestVersionId())) {
             throw handleClientException(ERROR_CODE_CANNOT_DELETE_LATEST_PURPOSE_VERSION, versionUuid);
         }
@@ -1157,6 +1145,7 @@ public class ConsentManagerImpl implements ConsentManager {
         }
         if (purposes != null) {
             for (Purpose purpose : purposes) {
+                purpose.setTenantDomain(ConsentUtils.getTenantDomain(realmService, purpose.getTenantId()));
                 if (purpose.getLatestVersionId() != null) {
                     PurposeVersion latestVersion = getPurposeDAO(purposeDAOs)
                             .getPurposeVersionByUuid(purpose.getLatestVersionId());
@@ -1190,6 +1179,11 @@ public class ConsentManagerImpl implements ConsentManager {
                     expressionNodes, limit, getTenantIdFromCarbonContext());
         }
         fillMissingUuids(categories);
+        if (categories != null) {
+            for (PIICategory category : categories) {
+                category.setTenantDomain(ConsentUtils.getTenantDomain(realmService, category.getTenantId()));
+            }
+        }
         return categories;
     }
 

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -72,6 +72,7 @@ import java.security.PublicKey;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -2054,7 +2055,7 @@ public class ConsentManagerImpl implements ConsentManager {
         try {
             String orgId = resolveCurrentOrganizationId();
             List<Purpose> merged = orgResourceResolverService
-                    .<List<Purpose>>getResourcesFromOrgHierarchy(orgId,
+                    .getResourcesFromOrgHierarchy(orgId,
                             hierarchyOrgId -> {
                                 try {
                                     int tenantId = getTenantIdFromOrgId(hierarchyOrgId);
@@ -2075,7 +2076,11 @@ public class ConsentManagerImpl implements ConsentManager {
                                 }
                                 return new ArrayList<>(byUuid.values());
                             }));
-            return merged != null ? merged : new ArrayList<>();
+            if (merged == null) {
+                return new ArrayList<>();
+            }
+            merged.sort(Comparator.comparingInt(p -> p.getId() != null ? p.getId() : 0));
+            return merged;
         } catch (OrgResourceHierarchyTraverseException e) {
             throw handleServerException(ERROR_CODE_ORGANIZATION_TRAVERSAL, getTenantDomainFromCarbonContext(), e);
         } catch (RuntimeException e) {
@@ -2093,7 +2098,7 @@ public class ConsentManagerImpl implements ConsentManager {
         try {
             String orgId = resolveCurrentOrganizationId();
             List<PIICategory> merged = orgResourceResolverService
-                    .<List<PIICategory>>getResourcesFromOrgHierarchy(orgId,
+                    .getResourcesFromOrgHierarchy(orgId,
                             hierarchyOrgId -> {
                                 try {
                                     int tenantId = getTenantIdFromOrgId(hierarchyOrgId);
@@ -2104,7 +2109,7 @@ public class ConsentManagerImpl implements ConsentManager {
                                     throw new RuntimeException(e);
                                 }
                             },
-                            new MergeAllAggregationStrategy<List<PIICategory>>((accumulated, fromParent) -> {
+                            new MergeAllAggregationStrategy<>((accumulated, fromParent) -> {
                                 Map<String, PIICategory> byUuid = new LinkedHashMap<>();
                                 for (PIICategory c : accumulated) {
                                     byUuid.put(c.getUuid(), c);
@@ -2114,7 +2119,11 @@ public class ConsentManagerImpl implements ConsentManager {
                                 }
                                 return new ArrayList<>(byUuid.values());
                             }));
-            return merged != null ? merged : new ArrayList<>();
+            if (merged == null) {
+                return new ArrayList<>();
+            }
+            merged.sort(Comparator.comparingInt(c -> c.getId() != null ? c.getId() : 0));
+            return merged;
         } catch (OrgResourceHierarchyTraverseException e) {
             throw handleServerException(ERROR_CODE_ORGANIZATION_TRAVERSAL, getTenantDomainFromCarbonContext(), e);
         } catch (RuntimeException e) {

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -1097,9 +1097,6 @@ public class ConsentManagerImpl implements ConsentManager {
 
         PIICategory category = getPiiCategoryDAO(piiCategoryDAOs).getPIICategoryByUuid(uuid,
                 getTenantIdFromCarbonContext());
-        if (category == null && isSubOrganization()) {
-            category = findPIICategoryInHierarchy(uuid);
-        }
         if (category == null) {
             throw handleClientException(ERROR_CODE_ELEMENT_UUID_NOT_FOUND, uuid);
         }
@@ -1171,13 +1168,8 @@ public class ConsentManagerImpl implements ConsentManager {
         if (limit == 0) {
             limit = getDefaultLimitFromConfig();
         }
-        List<PIICategory> categories;
-        if (isSubOrganization()) {
-            categories = listPIICategoriesFromHierarchy(expressionNodes, limit);
-        } else {
-            categories = getPiiCategoryDAO(piiCategoryDAOs).listPIICategories(
-                    expressionNodes, limit, getTenantIdFromCarbonContext());
-        }
+        List<PIICategory> categories = getPiiCategoryDAO(piiCategoryDAOs).listPIICategories(
+                expressionNodes, limit, getTenantIdFromCarbonContext());
         fillMissingUuids(categories);
         if (categories != null) {
             for (PIICategory category : categories) {
@@ -2015,33 +2007,6 @@ public class ConsentManagerImpl implements ConsentManager {
         }
     }
 
-    private PIICategory findPIICategoryInHierarchy(String uuid) throws ConsentManagementException {
-
-        OrgResourceResolverService orgResourceResolverService = getOrgResourceResolverService();
-        try {
-            String orgId = resolveCurrentOrganizationId();
-            return orgResourceResolverService
-                    .getResourcesFromOrgHierarchy(orgId,
-                            hierarchyOrgId -> {
-                                try {
-                                    int tenantId = getTenantIdFromOrgId(hierarchyOrgId);
-                                    return Optional.ofNullable(
-                                            getPiiCategoryDAO(piiCategoryDAOs).getPIICategoryByUuid(uuid, tenantId));
-                                } catch (ConsentManagementException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            },
-                            new FirstFoundAggregationStrategy<>());
-        } catch (OrgResourceHierarchyTraverseException e) {
-            throw handleServerException(ERROR_CODE_ORGANIZATION_TRAVERSAL, getTenantDomainFromCarbonContext(), e);
-        } catch (RuntimeException e) {
-            if (e.getCause() instanceof ConsentManagementException) {
-                throw (ConsentManagementException) e.getCause();
-            }
-            throw e;
-        }
-    }
-
     private List<Purpose> listPurposesFromHierarchy(List<ExpressionNode> expressionNodes, int limit)
             throws ConsentManagementException {
 
@@ -2085,46 +2050,4 @@ public class ConsentManagerImpl implements ConsentManager {
         }
     }
 
-    private List<PIICategory> listPIICategoriesFromHierarchy(List<ExpressionNode> expressionNodes, int limit)
-            throws ConsentManagementException {
-
-        OrgResourceResolverService orgResourceResolverService = getOrgResourceResolverService();
-        try {
-            String orgId = resolveCurrentOrganizationId();
-            List<PIICategory> merged = orgResourceResolverService
-                    .getResourcesFromOrgHierarchy(orgId,
-                            hierarchyOrgId -> {
-                                try {
-                                    int tenantId = getTenantIdFromOrgId(hierarchyOrgId);
-                                    List<PIICategory> list = getPiiCategoryDAO(piiCategoryDAOs)
-                                            .listPIICategories(expressionNodes, limit, tenantId);
-                                    return (list != null && !list.isEmpty()) ? Optional.of(list) : Optional.empty();
-                                } catch (ConsentManagementException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            },
-                            new MergeAllAggregationStrategy<>((accumulated, fromParent) -> {
-                                Map<String, PIICategory> byUuid = new LinkedHashMap<>();
-                                for (PIICategory c : accumulated) {
-                                    byUuid.put(c.getUuid(), c);
-                                }
-                                for (PIICategory c : fromParent) {
-                                    byUuid.putIfAbsent(c.getUuid(), c);
-                                }
-                                return new ArrayList<>(byUuid.values());
-                            }));
-            if (merged == null) {
-                return new ArrayList<>();
-            }
-            merged.sort(Comparator.comparingInt(c -> c.getId() != null ? c.getId() : 0));
-            return merged;
-        } catch (OrgResourceHierarchyTraverseException e) {
-            throw handleServerException(ERROR_CODE_ORGANIZATION_TRAVERSAL, getTenantDomainFromCarbonContext(), e);
-        } catch (RuntimeException e) {
-            if (e.getCause() instanceof ConsentManagementException) {
-                throw (ConsentManagementException) e.getCause();
-            }
-            throw e;
-        }
-    }
 }

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -1080,6 +1080,7 @@ public class ConsentManagerImpl implements ConsentManager {
         if (purpose == null) {
             throw handleClientException(ERROR_CODE_PURPOSE_UUID_NOT_FOUND, uuid);
         }
+        purpose.setTenantDomain(ConsentUtils.getTenantDomain(realmService, purpose.getTenantId()));
         List<PurposePIICategory> purposePIICategories = new ArrayList<>();
         purpose.getPurposePIICategories().forEach(rethrowConsumer(
                 piiCategory -> purposePIICategories.add(getPurposePIICategoryWithUuid(piiCategory))));
@@ -1100,6 +1101,7 @@ public class ConsentManagerImpl implements ConsentManager {
         if (category == null) {
             throw handleClientException(ERROR_CODE_ELEMENT_UUID_NOT_FOUND, uuid);
         }
+        category.setTenantDomain(ConsentUtils.getTenantDomain(realmService, category.getTenantId()));
         return category;
     }
 

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/InterceptingConsentManager.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/InterceptingConsentManager.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.consent.mgt.core.model.ConsentManagerConfigurationHolder;
 import org.wso2.carbon.consent.mgt.core.model.PIICategory;
 import org.wso2.carbon.consent.mgt.core.model.Purpose;
 import org.wso2.carbon.consent.mgt.core.model.PurposeCategory;
+import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.model.Receipt;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptListResponse;
 import org.wso2.carbon.consent.mgt.core.util.ConsentUtils;
@@ -44,10 +45,12 @@ import java.util.List;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.wso2.carbon.CarbonConstants.UI_PERMISSION_ACTION;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_ELEMENT_UUID_NOT_FOUND;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_PII_CATEGORY_ID_INVALID;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_PURPOSE_CATEGORY_ID_INVALID;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_PURPOSE_ID_INVALID;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_PURPOSE_UUID_NOT_FOUND;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_RECEIPT_ID_INVALID;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_UNEXPECTED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED;
@@ -255,6 +258,91 @@ public class InterceptingConsentManager extends PrivilegedConsentManagerImpl {
         }
 
         return receipt;
+    }
+
+    /**
+     * Delete Purpose (UUID) after validating the tenant domain of the Purpose.
+     *
+     * @param uuid Purpose UUID.
+     * @throws ConsentManagementException Consent Management Exception if the tenant domain of the Purpose is
+     * different from the accessing tenant domain.
+     */
+    @Override
+    public void deletePurpose(String uuid) throws ConsentManagementException {
+
+        Purpose purpose = super.getPurposeByUuid(uuid);
+        if (isCrossTenantOperation(ConsentUtils.getTenantDomainFromCarbonContext(),
+                IdentityTenantUtil.getTenantDomain(purpose.getTenantId()))) {
+            String message = String.format(ERROR_CODE_PURPOSE_UUID_NOT_FOUND.getMessage(), uuid) + " in tenant: " +
+                    ConsentUtils.getTenantDomainFromCarbonContext();
+            throw new ConsentManagementClientException(message, ERROR_CODE_PURPOSE_UUID_NOT_FOUND.getCode());
+        }
+        super.deletePurpose(uuid);
+    }
+
+    /**
+     * Delete PII Category (UUID) after validating the tenant domain of the PII Category.
+     *
+     * @param uuid PII Category UUID.
+     * @throws ConsentManagementException Consent Management Exception if the tenant domain of the PII Category is
+     * different from the accessing tenant domain.
+     */
+    @Override
+    public void deletePIICategory(String uuid) throws ConsentManagementException {
+
+        PIICategory category = super.getPIICategoryByUuid(uuid);
+        if (isCrossTenantOperation(ConsentUtils.getTenantDomainFromCarbonContext(),
+                IdentityTenantUtil.getTenantDomain(category.getTenantId()))) {
+            String message = String.format(ERROR_CODE_ELEMENT_UUID_NOT_FOUND.getMessage(), uuid) + " in tenant: " +
+                    ConsentUtils.getTenantDomainFromCarbonContext();
+            throw new ConsentManagementClientException(message, ERROR_CODE_ELEMENT_UUID_NOT_FOUND.getCode());
+        }
+        super.deletePIICategory(uuid);
+    }
+
+    /**
+     * Add Purpose Version after validating the tenant domain of the parent Purpose.
+     *
+     * @param purposeUuid    UUID of the purpose.
+     * @param purposeVersion Purpose version to add.
+     * @param setAsLatest    Whether to mark this version as the latest.
+     * @return Created PurposeVersion.
+     * @throws ConsentManagementException Consent Management Exception if the tenant domain of the Purpose is
+     * different from the accessing tenant domain.
+     */
+    @Override
+    public PurposeVersion addPurposeVersion(String purposeUuid, PurposeVersion purposeVersion, boolean setAsLatest)
+            throws ConsentManagementException {
+
+        Purpose purpose = super.getPurposeByUuid(purposeUuid);
+        if (isCrossTenantOperation(ConsentUtils.getTenantDomainFromCarbonContext(),
+                IdentityTenantUtil.getTenantDomain(purpose.getTenantId()))) {
+            String message = String.format(ERROR_CODE_PURPOSE_UUID_NOT_FOUND.getMessage(), purposeUuid) +
+                    " in tenant: " + ConsentUtils.getTenantDomainFromCarbonContext();
+            throw new ConsentManagementClientException(message, ERROR_CODE_PURPOSE_UUID_NOT_FOUND.getCode());
+        }
+        return super.addPurposeVersion(purposeUuid, purposeVersion, setAsLatest);
+    }
+
+    /**
+     * Delete Purpose Version after validating the tenant domain of the parent Purpose.
+     *
+     * @param purposeUuid UUID of the purpose.
+     * @param versionUuid UUID of the version record.
+     * @throws ConsentManagementException Consent Management Exception if the tenant domain of the Purpose is
+     * different from the accessing tenant domain.
+     */
+    @Override
+    public void deletePurposeVersion(String purposeUuid, String versionUuid) throws ConsentManagementException {
+
+        Purpose purpose = super.getPurposeByUuid(purposeUuid);
+        if (isCrossTenantOperation(ConsentUtils.getTenantDomainFromCarbonContext(),
+                IdentityTenantUtil.getTenantDomain(purpose.getTenantId()))) {
+            String message = String.format(ERROR_CODE_PURPOSE_UUID_NOT_FOUND.getMessage(), purposeUuid) +
+                    " in tenant: " + ConsentUtils.getTenantDomainFromCarbonContext();
+            throw new ConsentManagementClientException(message, ERROR_CODE_PURPOSE_UUID_NOT_FOUND.getCode());
+        }
+        super.deletePurposeVersion(purposeUuid, versionUuid);
     }
 
     /**


### PR DESCRIPTION
Related issue https://github.com/wso2/product-is/issues/26859

### Summary
 - Remove org traversal for PII categories
 - Fix pagination for inherited policies
 
### Purpose

This pull request refactors tenant domain validation logic for purpose and PII category operations in the consent management core module. The main change is moving cross-tenant validation checks from `ConsentManagerImpl` to `InterceptingConsentManager`, centralizing access control and improving maintainability. Additionally, the code now consistently sets the tenant domain on returned models and removes unnecessary hierarchical queries for PII categories.