### PR TITLE
Create webhooks for consent management

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/pom.xml
+++ b/components/org.wso2.carbon.consent.mgt.core/pom.xml
@@ -124,6 +124,8 @@
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.model; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.context; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.context.model; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event.*; version="${carbon.identity.framework.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -44,10 +44,7 @@ import org.wso2.carbon.identity.core.model.ExpressionNode;
 import java.util.List;
 import java.util.Map;
 
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.APPROVED_STATE;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.REJECTED_STATE;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP_TYPE;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.*;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.POST_ADD_PII_CATEGORY;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.POST_ADD_PURPOSE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.POST_ADD_PURPOSE_CATEGORY;
@@ -118,30 +115,6 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.Interce
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.PRE_SET_LATEST_PURPOSE_VERSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.PRE_UPDATE_CONSENT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.PRE_VALIDATE_CONSENT_STATUS;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.LIMIT;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.OFFSET;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PII_CATEGORY;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PII_CATEGORY_ID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PII_CATEGORY_NAME;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PII_CATEGORY_UUID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PII_PRINCIPAL_ID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PRINCIPAL_TENANT_DOMAIN;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_CATEGORY;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_CATEGORY_ID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_CATEGORY_NAME;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_ID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_NAME;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_UUID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PURPOSE_VERSION_LABEL;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.RECEIPT_ID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.RECEIPT_UPDATE_INPUT;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.RECEIPT_INPUT;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.SERVICE;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.SP_TENANT_DOMAIN;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.STATE;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.TENANT_ID;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.VERSION_ID;
 
 /**
  * Consent Manager intercepting layer responsible for triggering listeners and calling the actual
@@ -803,33 +776,31 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
 
     public AddReceiptResponse addConsent(ReceiptInput receiptInput) throws ConsentManagementException {
 
-        String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
-        List<ConsentManagementListener> listeners =
-                ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
-        for (ConsentManagementListener listener : listeners) {
-            if (listener.isEnable()) {
-                listener.preAddConsent(receiptInput, tenantDomain);
-            }
-        }
-        ConsentEventPublisherProxy.getInstance().publishPreAddConsentWithException(receiptInput, tenantDomain);
-
-        ConsentMessageContext context = new ConsentMessageContext();
-        ConsentInterceptorTemplate<AddReceiptResponse, ConsentManagementException>
-                template = new ConsentInterceptorTemplate<>(consentMgtInterceptors, context);
-
         Flow.Name flowName;
-        Flow.InitiatingPersona persona = Flow.InitiatingPersona.USER;
-        if (REJECTED_STATE.equals(receiptInput.getState())) {
-            flowName = Flow.Name.CONSENT_REJECT;
-        } else if (DEFAULT_COLLECTION_METHOD.equals(receiptInput.getCollectionMethod())
+        Flow.InitiatingPersona persona;
+        if (DEFAULT_COLLECTION_METHOD.equals(receiptInput.getCollectionMethod())
                 && receiptInput.getAuthorizations() != null && !receiptInput.getAuthorizations().isEmpty()) {
-            flowName = Flow.Name.CONSENT_PENDING;
+            flowName = Flow.Name.CONSENT_CREATE;
             persona = Flow.InitiatingPersona.ADMIN;
         } else {
-            flowName = Flow.Name.CONSENT_ACCEPT;
+            flowName = getFlowInitiatingName(Flow.Name.CONSENT_GRANT);
+            persona = getFlowInitiatingPersona(Flow.InitiatingPersona.USER);
         }
         enterFlow(flowName, persona);
         try {
+            String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
+            List<ConsentManagementListener> listeners =
+                    ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
+            for (ConsentManagementListener listener : listeners) {
+                if (listener.isEnable()) {
+                    listener.preAddConsent(receiptInput, tenantDomain);
+                }
+            }
+            ConsentEventPublisherProxy.getInstance().publishPreAddConsentWithException(receiptInput, tenantDomain);
+
+            ConsentMessageContext context = new ConsentMessageContext();
+            ConsentInterceptorTemplate<AddReceiptResponse, ConsentManagementException>
+                    template = new ConsentInterceptorTemplate<>(consentMgtInterceptors, context);
             AddReceiptResponse result = template
                     .intercept(PRE_ADD_RECEIPT, properties -> properties.put(RECEIPT_INPUT, receiptInput))
                     .executeWith(new OperationDelegate<AddReceiptResponse>() {
@@ -1134,7 +1105,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
     public PurposeVersion addPurposeVersion(String purposeUuid, PurposeVersion purposeVersion, boolean setAsLatest)
             throws ConsentManagementException {
 
-        enterFlow(Flow.Name.CONSENT_PURPOSE_VERSION_ADD, Flow.InitiatingPersona.ADMIN);
+        enterFlow(Flow.Name.PURPOSE_UPDATE, Flow.InitiatingPersona.ADMIN);
         try {
             String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
             List<ConsentManagementListener> listeners =
@@ -1247,7 +1218,7 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
     private void enterFlow(Flow.Name flowName, Flow.InitiatingPersona persona) {
 
         IdentityContext.getThreadLocalIdentityContext().enterFlow(
-                new Flow.Builder().name(flowName).initiatingPersona(getFlowInitiatingPersona(persona)).build());
+                new Flow.Builder().name(flowName).initiatingPersona(persona).build());
     }
 
     private Flow.InitiatingPersona getFlowInitiatingPersona(Flow.InitiatingPersona defaultPersona) {
@@ -1257,6 +1228,15 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
             return existingFlow.getInitiatingPersona();
         }
         return defaultPersona;
+    }
+
+    private Flow.Name getFlowInitiatingName(Flow.Name defaultFlowName) {
+
+        Flow existingFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+        if (existingFlow != null) {
+            return existingFlow.getName();
+        }
+        return defaultFlowName;
     }
 
     private void populateProperties(int limit, int offset, String piiPrincipalId, String spTenantDomain, String
@@ -1287,14 +1267,15 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
             throws ConsentManagementException {
 
         Flow.Name flowName;
-        if (APPROVED_STATE.equals(authStatus)) {
-            flowName = Flow.Name.CONSENT_ACCEPT;
-        } else if (REJECTED_STATE.equals(authStatus)) {
-            flowName = Flow.Name.CONSENT_REJECT;
-        } else {
+        Flow.InitiatingPersona persona;
+        if (REVOKE_STATE.equals(authStatus)) {
             flowName = Flow.Name.CONSENT_REVOKE;
+            persona = getFlowInitiatingPersona(Flow.InitiatingPersona.USER);
+        } else {
+            flowName = Flow.Name.CONSENT_GRANT;
+            persona = Flow.InitiatingPersona.USER;
         }
-        enterFlow(flowName, Flow.InitiatingPersona.USER);
+        enterFlow(flowName, persona);
         try {
             String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
             List<ConsentManagementListener> listeners =

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -37,12 +37,16 @@ import org.wso2.carbon.consent.mgt.core.model.ReceiptUpdateInput;
 import org.wso2.carbon.consent.mgt.core.internal.ConsentManagerComponentDataHolder;
 import org.wso2.carbon.consent.mgt.core.listener.ConsentManagementListener;
 import org.wso2.carbon.consent.mgt.core.util.ConsentUtils;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.APPROVED_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.REJECTED_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.GROUP_TYPE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.POST_ADD_PII_CATEGORY;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.InterceptorConstants.POST_ADD_PURPOSE;
@@ -156,6 +160,8 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.VERSION
         }
 )
 public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
+
+    private static final String DEFAULT_COLLECTION_METHOD = "V2";
 
     private ConsentManager consentManager;
     protected List<ConsentMgtInterceptor> consentMgtInterceptors;
@@ -811,25 +817,41 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
         ConsentInterceptorTemplate<AddReceiptResponse, ConsentManagementException>
                 template = new ConsentInterceptorTemplate<>(consentMgtInterceptors, context);
 
-        AddReceiptResponse result = template
-                .intercept(PRE_ADD_RECEIPT, properties -> properties.put(RECEIPT_INPUT, receiptInput))
-                .executeWith(new OperationDelegate<AddReceiptResponse>() {
-                    @Override
-                    public AddReceiptResponse execute() throws ConsentManagementException {
-
-                        return consentManager.addConsent(receiptInput);
-                    }
-                })
-                .intercept(POST_ADD_RECEIPT, properties -> properties.put(RECEIPT_INPUT, receiptInput))
-                .getResult();
-
-        ConsentEventPublisherProxy.getInstance().publishPostAddConsent(receiptInput, tenantDomain);
-        for (ConsentManagementListener listener : listeners) {
-            if (listener.isEnable()) {
-                listener.postAddConsent(receiptInput, tenantDomain);
-            }
+        Flow.Name flowName;
+        Flow.InitiatingPersona persona = Flow.InitiatingPersona.USER;
+        if (REJECTED_STATE.equals(receiptInput.getState())) {
+            flowName = Flow.Name.CONSENT_REJECT;
+        } else if (DEFAULT_COLLECTION_METHOD.equals(receiptInput.getCollectionMethod())
+                && receiptInput.getAuthorizations() != null && !receiptInput.getAuthorizations().isEmpty()) {
+            flowName = Flow.Name.CONSENT_PENDING;
+            persona = Flow.InitiatingPersona.ADMIN;
+        } else {
+            flowName = Flow.Name.CONSENT_ACCEPT;
         }
-        return result;
+        enterFlow(flowName, persona);
+        try {
+            AddReceiptResponse result = template
+                    .intercept(PRE_ADD_RECEIPT, properties -> properties.put(RECEIPT_INPUT, receiptInput))
+                    .executeWith(new OperationDelegate<AddReceiptResponse>() {
+                        @Override
+                        public AddReceiptResponse execute() throws ConsentManagementException {
+
+                            return consentManager.addConsent(receiptInput);
+                        }
+                    })
+                    .intercept(POST_ADD_RECEIPT, properties -> properties.put(RECEIPT_INPUT, receiptInput))
+                    .getResult();
+
+            ConsentEventPublisherProxy.getInstance().publishPostAddConsent(receiptInput, tenantDomain);
+            for (ConsentManagementListener listener : listeners) {
+                if (listener.isEnable()) {
+                    listener.postAddConsent(receiptInput, tenantDomain);
+                }
+            }
+            return result;
+        } finally {
+            IdentityContext.getThreadLocalIdentityContext().exitFlow();
+        }
     }
 
     public Receipt getReceipt(String receiptId) throws ConsentManagementException {
@@ -1112,46 +1134,51 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
     public PurposeVersion addPurposeVersion(String purposeUuid, PurposeVersion purposeVersion, boolean setAsLatest)
             throws ConsentManagementException {
 
-        String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
-        List<ConsentManagementListener> listeners =
-                ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
-        for (ConsentManagementListener listener : listeners) {
-            if (listener.isEnable()) {
-                listener.preAddPurposeVersion(purposeUuid, purposeVersion, tenantDomain);
+        enterFlow(Flow.Name.CONSENT_PURPOSE_VERSION_ADD, Flow.InitiatingPersona.ADMIN);
+        try {
+            String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
+            List<ConsentManagementListener> listeners =
+                    ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
+            for (ConsentManagementListener listener : listeners) {
+                if (listener.isEnable()) {
+                    listener.preAddPurposeVersion(purposeUuid, purposeVersion, tenantDomain);
+                }
             }
-        }
-        ConsentEventPublisherProxy.getInstance().publishPreAddPurposeVersionWithException(
-                purposeUuid, purposeVersion, setAsLatest, tenantDomain);
+            ConsentEventPublisherProxy.getInstance().publishPreAddPurposeVersionWithException(
+                    purposeUuid, purposeVersion, setAsLatest, tenantDomain);
 
-        ConsentMessageContext context = new ConsentMessageContext();
-        ConsentInterceptorTemplate<PurposeVersion, ConsentManagementException>
-                template = new ConsentInterceptorTemplate<>(consentMgtInterceptors, context);
+            ConsentMessageContext context = new ConsentMessageContext();
+            ConsentInterceptorTemplate<PurposeVersion, ConsentManagementException>
+                    template = new ConsentInterceptorTemplate<>(consentMgtInterceptors, context);
 
-        PurposeVersion result = template.intercept(PRE_ADD_PURPOSE_VERSION, properties -> {
-                    properties.put(PURPOSE_ID, purposeUuid);
-                    properties.put("PURPOSE_VERSION", purposeVersion);
-                })
-                .executeWith(new OperationDelegate<PurposeVersion>() {
-                    @Override
-                    public PurposeVersion execute() throws ConsentManagementException {
+            PurposeVersion result = template.intercept(PRE_ADD_PURPOSE_VERSION, properties -> {
+                        properties.put(PURPOSE_ID, purposeUuid);
+                        properties.put("PURPOSE_VERSION", purposeVersion);
+                    })
+                    .executeWith(new OperationDelegate<PurposeVersion>() {
+                        @Override
+                        public PurposeVersion execute() throws ConsentManagementException {
 
-                        return consentManager.addPurposeVersion(purposeUuid, purposeVersion, setAsLatest);
-                    }
-                })
-                .intercept(POST_ADD_PURPOSE_VERSION, properties -> {
-                    properties.put(PURPOSE_ID, purposeUuid);
-                    properties.put("PURPOSE_VERSION", purposeVersion);
-                })
-                .getResult();
+                            return consentManager.addPurposeVersion(purposeUuid, purposeVersion, setAsLatest);
+                        }
+                    })
+                    .intercept(POST_ADD_PURPOSE_VERSION, properties -> {
+                        properties.put(PURPOSE_ID, purposeUuid);
+                        properties.put("PURPOSE_VERSION", purposeVersion);
+                    })
+                    .getResult();
 
-        ConsentEventPublisherProxy.getInstance().publishPostAddPurposeVersion(purposeUuid, result, setAsLatest,
-                tenantDomain);
-        for (ConsentManagementListener listener : listeners) {
-            if (listener.isEnable()) {
-                listener.postAddPurposeVersion(purposeUuid, result, tenantDomain);
+            ConsentEventPublisherProxy.getInstance().publishPostAddPurposeVersion(purposeUuid, result, setAsLatest,
+                    tenantDomain);
+            for (ConsentManagementListener listener : listeners) {
+                if (listener.isEnable()) {
+                    listener.postAddPurposeVersion(purposeUuid, result, tenantDomain);
+                }
             }
+            return result;
+        } finally {
+            IdentityContext.getThreadLocalIdentityContext().exitFlow();
         }
-        return result;
     }
 
     @Override
@@ -1217,6 +1244,21 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
         }
     }
 
+    private void enterFlow(Flow.Name flowName, Flow.InitiatingPersona persona) {
+
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(
+                new Flow.Builder().name(flowName).initiatingPersona(getFlowInitiatingPersona(persona)).build());
+    }
+
+    private Flow.InitiatingPersona getFlowInitiatingPersona(Flow.InitiatingPersona defaultPersona) {
+
+        Flow existingFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+        if (existingFlow != null) {
+            return existingFlow.getInitiatingPersona();
+        }
+        return defaultPersona;
+    }
+
     private void populateProperties(int limit, int offset, String piiPrincipalId, String spTenantDomain, String
             service, String state, Map<String, Object> properties) {
 
@@ -1244,46 +1286,59 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
     public void authorizeConsent(String consentId, String userId, String authStatus)
             throws ConsentManagementException {
 
-        String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
-        List<ConsentManagementListener> listeners =
-                ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
-        for (ConsentManagementListener listener : listeners) {
-            if (listener.isEnable()) {
-                listener.preAuthorizeConsent(consentId, userId, authStatus, tenantDomain);
-            }
+        Flow.Name flowName;
+        if (APPROVED_STATE.equals(authStatus)) {
+            flowName = Flow.Name.CONSENT_ACCEPT;
+        } else if (REJECTED_STATE.equals(authStatus)) {
+            flowName = Flow.Name.CONSENT_REJECT;
+        } else {
+            flowName = Flow.Name.CONSENT_REVOKE;
         }
-        ConsentEventPublisherProxy.getInstance().publishPreAuthorizeConsentWithException(
-                consentId, userId, authStatus, tenantDomain);
-
-        ConsentMessageContext context = new ConsentMessageContext();
-        ConsentInterceptorTemplate<Void, ConsentManagementException>
-                template = new ConsentInterceptorTemplate<>(consentMgtInterceptors, context);
-
-        template.intercept(PRE_AUTHORIZE_CONSENT, properties -> {
-                    properties.put(RECEIPT_ID, consentId);
-                    properties.put("USER_ID", userId);
-                    properties.put("AUTH_STATUS", authStatus);
-                })
-                .executeWith(new OperationDelegate<Void>() {
-                    @Override
-                    public Void execute() throws ConsentManagementException {
-
-                        consentManager.authorizeConsent(consentId, userId, authStatus);
-                        return null;
-                    }
-                })
-                .intercept(POST_AUTHORIZE_CONSENT, properties -> {
-                    properties.put(RECEIPT_ID, consentId);
-                    properties.put("USER_ID", userId);
-                    properties.put("AUTH_STATUS", authStatus);
-                });
-
-        ConsentEventPublisherProxy.getInstance().publishPostAuthorizeConsent(
-                consentId, userId, authStatus, tenantDomain);
-        for (ConsentManagementListener listener : listeners) {
-            if (listener.isEnable()) {
-                listener.postAuthorizeConsent(consentId, userId, authStatus, tenantDomain);
+        enterFlow(flowName, Flow.InitiatingPersona.USER);
+        try {
+            String tenantDomain = ConsentUtils.getTenantDomainFromCarbonContext();
+            List<ConsentManagementListener> listeners =
+                    ConsentManagerComponentDataHolder.getInstance().getConsentManagementListeners();
+            for (ConsentManagementListener listener : listeners) {
+                if (listener.isEnable()) {
+                    listener.preAuthorizeConsent(consentId, userId, authStatus, tenantDomain);
+                }
             }
+            ConsentEventPublisherProxy.getInstance().publishPreAuthorizeConsentWithException(
+                    consentId, userId, authStatus, tenantDomain);
+
+            ConsentMessageContext context = new ConsentMessageContext();
+            ConsentInterceptorTemplate<Void, ConsentManagementException>
+                    template = new ConsentInterceptorTemplate<>(consentMgtInterceptors, context);
+
+            template.intercept(PRE_AUTHORIZE_CONSENT, properties -> {
+                        properties.put(RECEIPT_ID, consentId);
+                        properties.put("USER_ID", userId);
+                        properties.put("AUTH_STATUS", authStatus);
+                    })
+                    .executeWith(new OperationDelegate<Void>() {
+                        @Override
+                        public Void execute() throws ConsentManagementException {
+
+                            consentManager.authorizeConsent(consentId, userId, authStatus);
+                            return null;
+                        }
+                    })
+                    .intercept(POST_AUTHORIZE_CONSENT, properties -> {
+                        properties.put(RECEIPT_ID, consentId);
+                        properties.put("USER_ID", userId);
+                        properties.put("AUTH_STATUS", authStatus);
+                    });
+
+            ConsentEventPublisherProxy.getInstance().publishPostAuthorizeConsent(
+                    consentId, userId, authStatus, tenantDomain);
+            for (ConsentManagementListener listener : listeners) {
+                if (listener.isEnable()) {
+                    listener.postAuthorizeConsent(consentId, userId, authStatus, tenantDomain);
+                }
+            }
+        } finally {
+            IdentityContext.getThreadLocalIdentityContext().exitFlow();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <org.json.wso2.version>3.0.0.wso2v1</org.json.wso2.version>
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
-        <carbon.identity.framework.version>7.10.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.139-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.8.0, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <org.wso2.carbon.identity.organization.management.core.version>1.1.48</org.wso2.carbon.identity.organization.management.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <org.json.wso2.version>3.0.0.wso2v1</org.json.wso2.version>
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
-        <carbon.identity.framework.version>7.11.139-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.143</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.8.0, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <org.wso2.carbon.identity.organization.management.core.version>1.1.48</org.wso2.carbon.identity.organization.management.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <org.json.wso2.version>3.0.0.wso2v1</org.json.wso2.version>
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
-        <carbon.identity.framework.version>7.11.143</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.145</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.8.0, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <org.wso2.carbon.identity.organization.management.core.version>1.1.48</org.wso2.carbon.identity.organization.management.core.version>


### PR DESCRIPTION
This pull request enhances the consent management core by integrating identity flow context tracking into key consent operations. The main changes introduce flow state management using the `IdentityContext` and `Flow` classes, ensuring that consent actions are properly tracked and attributed to the correct initiating persona (user or admin). This improves auditing, debugging, and future extensibility of consent operations.

The most important changes are:

**Identity Flow Context Integration:**
* Added imports and OSGi package exports for `org.wso2.carbon.identity.core.context` and `org.wso2.carbon.identity.core.context.model` to enable flow context usage in the consent core module. [[1]](diffhunk://#diff-bad66fa06b1a2c054e79e322d63e17e82f8a88ac50ac5ec1a0e7936c1621087cR127-R128) [[2]](diffhunk://#diff-294ccc62cb5ae96087853e3ade1b442f6e428b226e5cd27354334e7c5c034e4aR40-R49)
* Updated methods such as `addConsent`, `addPurposeVersion`, and `authorizeConsent` in `PrivilegedConsentManagerImpl` to enter the appropriate flow (e.g., CONSENT_ACCEPT, CONSENT_REJECT, CONSENT_PENDING, CONSENT_PURPOSE_VERSION_ADD, CONSENT_REVOKE) at the start of the operation and ensure the flow is properly exited in a `finally` block.

**Code Structure and Utility Improvements:**
* Introduced the `enterFlow` and `getFlowInitiatingPersona` helper methods in `PrivilegedConsentManagerImpl` to encapsulate flow entry logic and persona resolution, improving code clarity and reducing duplication.
* Defined a `DEFAULT_COLLECTION_METHOD` constant to standardize collection method checks in consent logic.

**Dependency Updates:**
* Bumped the `carbon.identity.framework.version` to `7.11.139-SNAPSHOT` to ensure compatibility with the new identity context features.