### PR TITLE
Fix consent list state filtering for lazily-resolved EXPIRED/PENDING states

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/constant/SQLConstants.java
@@ -544,6 +544,11 @@ public class SQLConstants {
     public static final String LIST_RECEIPTS_ACTIVE_EXPIRY_CONDITION =
             " AND (r2.EXPIRY_TIME IS NULL OR r2.EXPIRY_TIME > ?)";
 
+    // EXPIRED is computed lazily (never persisted); a receipt is expired when it is stored as
+    // ACTIVE/PENDING and its expiry time has passed. Mirrors resolveConsentState() in ConsentManagerImpl.
+    public static final String LIST_RECEIPTS_EXPIRED_CONDITION =
+            " AND r2.STATE IN ('ACTIVE', 'PENDING') AND r2.EXPIRY_TIME IS NOT NULL AND r2.EXPIRY_TIME <= ?";
+
     public static final String LIST_RECEIPTS_SQL_TAIL =
             " ORDER BY sub_ck ASC LIMIT ?" +
             "  ) inner_receipts" +

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/dao/impl/ReceiptDAOImpl.java
@@ -60,6 +60,8 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.FilterC
 import static java.time.ZoneOffset.UTC;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ACTIVE_STATE;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.EXPIRED_STATE;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PENDING_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.REVOKE_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.DELETE_RECEIPTS_BY_PRINCIPAL_TENANT_ID_SQL;
@@ -116,6 +118,7 @@ import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.SEARCH_RECE
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.SEARCH_RECEIPT_SQL_WITHOUT_SP_TENANT_MSSQL;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.SEARCH_RECEIPT_SQL_WITHOUT_SP_TENANT_ORACLE;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.LIST_RECEIPTS_ACTIVE_EXPIRY_CONDITION;
+import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.LIST_RECEIPTS_EXPIRED_CONDITION;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.LIST_RECEIPTS_SQL_HEAD;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.LIST_RECEIPTS_SQL_TAIL;
 import static org.wso2.carbon.consent.mgt.core.constant.SQLConstants.LIST_RECEIPTS_SQL_TAIL_MSSQL;
@@ -1534,11 +1537,15 @@ public class ReceiptDAOImpl implements ReceiptDAO {
                         preparedStatement.setInt(paramIndex++, tenantId);
                         preparedStatement.setString(paramIndex++, finalSubjectId);
                         preparedStatement.setString(paramIndex++, finalServiceId);
-                        preparedStatement.setString(paramIndex++, finalState);
+                        // EXPIRED is computed lazily and never stored, so the STATE LIKE filter must match any
+                        // stored state; the appended expired condition constrains STATE to ACTIVE/PENDING itself.
+                        preparedStatement.setString(paramIndex++,
+                                EXPIRED_STATE.equals(finalState) ? SQL_FILTER_STRING_ANY : finalState);
                         preparedStatement.setString(paramIndex++, finalPurposeId);
                         preparedStatement.setString(paramIndex++, finalPurposeVersionId);
-                        // The active-expiry condition compares EXPIRY_TIME against "now" in UTC.
-                        if (ACTIVE_STATE.equals(finalState)) {
+                        // The active/pending and expired expiry conditions compare EXPIRY_TIME against "now" in UTC.
+                        if (ACTIVE_STATE.equals(finalState) || PENDING_STATE.equals(finalState)
+                                || EXPIRED_STATE.equals(finalState)) {
                             preparedStatement.setTimestamp(paramIndex++, new Timestamp(System.currentTimeMillis()),
                                     Calendar.getInstance(TimeZone.getTimeZone(UTC)));
                         }
@@ -1572,8 +1579,12 @@ public class ReceiptDAOImpl implements ReceiptDAO {
         int propIndex = 0;
         String valueCol = getReceiptPropertyValueColumn();
 
-        if (ACTIVE_STATE.equals(state)) {
+        // ACTIVE and PENDING are both lazily re-labelled to EXPIRED once their expiry passes
+        // (see resolveConsentState in ConsentManagerImpl), so both must exclude expired rows.
+        if (ACTIVE_STATE.equals(state) || PENDING_STATE.equals(state)) {
             propertyConditions.append(LIST_RECEIPTS_ACTIVE_EXPIRY_CONDITION);
+        } else if (EXPIRED_STATE.equals(state)) {
+            propertyConditions.append(LIST_RECEIPTS_EXPIRED_CONDITION);
         }
 
         for (ExpressionNode node : expressionNodes) {


### PR DESCRIPTION
## Purpose

Consent expiry is resolved lazily at read time — `EXPIRED` is never persisted to `CM_RECEIPT.STATE`. Instead, `ConsentManagerImpl.resolveConsentState()` re-labels a stored `ACTIVE` or `PENDING` receipt to `EXPIRED` when its `EXPIRY_TIME` has passed.

The list/search path (`ReceiptDAOImpl.listReceipts`) filters on the *stored* state via `STATE LIKE ?`, which is inconsistent with this lazy resolution:

- **`state=EXPIRED`** compiled to `STATE LIKE 'EXPIRED'`, which matches **zero rows** (the value is never stored), so the filter always returned an empty result.
- **`state=PENDING`** had **no expiry guard**, so it **over-returned**: expired-pending receipts were returned by the query but then re-labelled to `EXPIRED` by the post-query resolver — a caller asking for `PENDING` got rows displayed as `EXPIRED`.

Only `state=ACTIVE` was handled correctly (it already had an expiry guard). `REVOKED`/`REJECTED` are unaffected because the resolver never re-labels them.

Resolves: <!-- link the tracking issue here -->

## Goals

Make SQL-level state filtering in the consent list API consistent with the lazy expiry resolution, so that every state filter returns exactly the set of receipts whose *resolved* state matches the requested value.

## Approach

The DAO now mirrors `resolveConsentState()` at the SQL level:

- **New SQL constant** `LIST_RECEIPTS_EXPIRED_CONDITION` in `SQLConstants.java`:
  ```sql
  AND r2.STATE IN ('ACTIVE', 'PENDING') AND r2.EXPIRY_TIME IS NOT NULL AND r2.EXPIRY_TIME <= ?
  ```
- **`ReceiptDAOImpl.buildCursorReceiptQuery`**:
  - `state=EXPIRED` → appends the new expired condition. The `STATE LIKE ?` parameter is bound to `%` (match any stored state) so the appended condition alone constrains the state.
  - `state=PENDING` → now appends the same "not expired" guard already used for `ACTIVE` (`AND (EXPIRY_TIME IS NULL OR EXPIRY_TIME > ?)`), so expired-pending rows are excluded.
- **Parameter binding** in `listReceipts` binds the current UTC timestamp for `ACTIVE`, `PENDING`, and `EXPIRED` filters.

Because the query returns rows stored as `ACTIVE`/`PENDING` (past expiry) for the `EXPIRED` filter, the existing post-query resolver in `ConsentManagerImpl.listReceipts` flips their displayed state to `EXPIRED`, keeping the output consistent.

No schema changes; no public API/signature changes (OSGi binary compatibility preserved).

## Relates issue

- https://github.com/wso2/product-is/issues/26859

## Test environment

- JDK: <!-- e.g. 11, 17 -->
- OS: macOS (darwin)
- Databases: H2 (unit tests). The new SQL uses only standard predicates (`IN`, `IS NULL`, comparison) and is compatible with all supported dialects (H2/MySQL/PostgreSQL/MSSQL/Oracle/DB2).