### PR TITLE
Add methods for self-service API

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManager.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManager.java
@@ -492,15 +492,15 @@ public interface ConsentManager {
     }
 
     /**
-     * Get all authorization records for a consent (V2 API), after validating that the given PII principal is
-     * either the owner of the receipt or a delegated authorizer on it. Falls back to
+     * Get all authorization records for a consent (V2 API), after validating that the given user is either the
+     * subject of the receipt or a delegated authorizer on it. Falls back to
      * {@link #getConsentAuthorizations(String)} (no ownership/authorizer check) for implementations that do not
      * override.
      *
-     * @param consentId      Consent receipt ID.
-     * @param piiPrincipalId PII principal ID expected to own or be authorized on the receipt.
+     * @param consentId Consent receipt ID.
+     * @param userId    ID of the user expected to be the subject or an authorizer on the receipt.
      */
-    default List<ConsentAuthorization> getConsentAuthorizations(String consentId, String piiPrincipalId)
+    default List<ConsentAuthorization> getConsentAuthorizations(String consentId, String userId)
             throws ConsentManagementException {
 
         return getConsentAuthorizations(consentId);

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManager.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManager.java
@@ -492,6 +492,21 @@ public interface ConsentManager {
     }
 
     /**
+     * Get all authorization records for a consent (V2 API), after validating that the given PII principal is
+     * either the owner of the receipt or a delegated authorizer on it. Falls back to
+     * {@link #getConsentAuthorizations(String)} (no ownership/authorizer check) for implementations that do not
+     * override.
+     *
+     * @param consentId      Consent receipt ID.
+     * @param piiPrincipalId PII principal ID expected to own or be authorized on the receipt.
+     */
+    default List<ConsentAuthorization> getConsentAuthorizations(String consentId, String piiPrincipalId)
+            throws ConsentManagementException {
+
+        return getConsentAuthorizations(consentId);
+    }
+
+    /**
      * Update an existing consent receipt's expiry time, properties, and/or authorizations.
      * Null fields in {@link ReceiptUpdateInput} are left unchanged.
      *
@@ -611,5 +626,19 @@ public interface ConsentManager {
     default Receipt getReceiptWithExtendedSchema(String receiptId) throws ConsentManagementException {
 
         return null;
+    }
+
+    /**
+     * Retrieve a receipt using extended schema after validating that it belongs to the given PII principal.
+     * Falls back to {@link #getReceiptWithExtendedSchema(String)} (no ownership check) for implementations
+     * that do not override.
+     *
+     * @param receiptId      Consent receipt ID.
+     * @param piiPrincipalId PII principal ID expected to own the receipt.
+     */
+    default Receipt getReceiptWithExtendedSchema(String receiptId, String piiPrincipalId)
+            throws ConsentManagementException {
+
+        return getReceiptWithExtendedSchema(receiptId);
     }
 }

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -142,6 +142,7 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMe
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_TENANT_ID_REQUIRED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_TERMINATION_IS_REQUIRED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_THIRD_PARTY_DISCLOSURE_IS_REQUIRED;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PIIControllerElements.ADDRESS;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PIIControllerElements.ADDRESS_COUNTRY;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PIIControllerElements.ADDRESS_LOCALITY;
@@ -808,6 +809,18 @@ public class ConsentManagerImpl implements ConsentManager {
         return receipt;
     }
 
+    @Override
+    public Receipt getReceiptWithExtendedSchema(String receiptId, String piiPrincipalId)
+            throws ConsentManagementException {
+
+        Receipt receipt = getReceiptWithExtendedSchema(receiptId);
+
+        if (!isSamePrincipal(piiPrincipalId, receipt.getPiiPrincipalId())) {
+            throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, piiPrincipalId);
+        }
+        return receipt;
+    }
+
     /**
      * This API is used to search receipts.
      *
@@ -1291,6 +1304,35 @@ public class ConsentManagerImpl implements ConsentManager {
             throws ConsentManagementException {
 
         return getReceiptsDAO(receiptDAOs).getConsentAuthorizations(consentId);
+    }
+
+    /**
+     * Retrieves all authorization records for a consent receipt, after validating that the given PII principal
+     * is either the owner of the receipt or a delegated authorizer on it.
+     *
+     * @param consentId      Consent receipt ID.
+     * @param piiPrincipalId PII principal ID expected to own or be authorized on the receipt.
+     * @return List of authorization records for the consent.
+     * @throws ConsentManagementException if the PII principal is neither the owner nor a delegated authorizer.
+     */
+    @Override
+    public List<ConsentAuthorization> getConsentAuthorizations(String consentId, String piiPrincipalId)
+            throws ConsentManagementException {
+
+        Receipt receipt = getReceiptWithExtendedSchema(consentId);
+        List<ConsentAuthorization> authorizations = getConsentAuthorizations(consentId);
+
+        if (isSamePrincipal(piiPrincipalId, receipt.getPiiPrincipalId())) {
+            return authorizations;
+        }
+        if (authorizations != null) {
+            for (ConsentAuthorization authorization : authorizations) {
+                if (isSamePrincipal(piiPrincipalId, authorization.getUserId())) {
+                    return authorizations;
+                }
+            }
+        }
+        throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, piiPrincipalId);
     }
 
     @Override
@@ -2000,6 +2042,22 @@ public class ConsentManagerImpl implements ConsentManager {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Checks whether the given PII principal ID refers to the same user as the other username, honouring the
+     * case-sensitivity configuration of the PII principal's userstore.
+     *
+     * @param piiPrincipalId PII principal ID to check.
+     * @param otherUserId    Other username to compare against.
+     * @return true if both refer to the same user.
+     * @throws ConsentManagementException if the userstore case-sensitivity cannot be resolved.
+     */
+    private boolean isSamePrincipal(String piiPrincipalId, String otherUserId) throws ConsentManagementException {
+
+        return isUserNameCaseSensitive(piiPrincipalId)
+                ? StringUtils.equals(piiPrincipalId, otherUserId)
+                : StringUtils.equalsIgnoreCase(getLowerCaseUserName(piiPrincipalId), otherUserId);
     }
 
     /**

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImpl.java
@@ -815,7 +815,7 @@ public class ConsentManagerImpl implements ConsentManager {
 
         Receipt receipt = getReceiptWithExtendedSchema(receiptId);
 
-        if (!isSamePrincipal(piiPrincipalId, receipt.getPiiPrincipalId())) {
+        if (!isSameUser(piiPrincipalId, receipt.getPiiPrincipalId())) {
             throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, piiPrincipalId);
         }
         return receipt;
@@ -1307,32 +1307,32 @@ public class ConsentManagerImpl implements ConsentManager {
     }
 
     /**
-     * Retrieves all authorization records for a consent receipt, after validating that the given PII principal
-     * is either the owner of the receipt or a delegated authorizer on it.
+     * Retrieves all authorization records for a consent receipt, after validating that the given user is either
+     * the subject of the receipt or a delegated authorizer on it.
      *
-     * @param consentId      Consent receipt ID.
-     * @param piiPrincipalId PII principal ID expected to own or be authorized on the receipt.
+     * @param consentId Consent receipt ID.
+     * @param userId    ID of the user expected to be the subject or an authorizer on the receipt.
      * @return List of authorization records for the consent.
-     * @throws ConsentManagementException if the PII principal is neither the owner nor a delegated authorizer.
+     * @throws ConsentManagementException if the user is neither the subject nor a delegated authorizer.
      */
     @Override
-    public List<ConsentAuthorization> getConsentAuthorizations(String consentId, String piiPrincipalId)
+    public List<ConsentAuthorization> getConsentAuthorizations(String consentId, String userId)
             throws ConsentManagementException {
 
         Receipt receipt = getReceiptWithExtendedSchema(consentId);
         List<ConsentAuthorization> authorizations = getConsentAuthorizations(consentId);
 
-        if (isSamePrincipal(piiPrincipalId, receipt.getPiiPrincipalId())) {
+        if (isSameUser(userId, receipt.getPiiPrincipalId())) {
             return authorizations;
         }
         if (authorizations != null) {
             for (ConsentAuthorization authorization : authorizations) {
-                if (isSamePrincipal(piiPrincipalId, authorization.getUserId())) {
+                if (isSameUser(userId, authorization.getUserId())) {
                     return authorizations;
                 }
             }
         }
-        throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, piiPrincipalId);
+        throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, userId);
     }
 
     @Override
@@ -2045,19 +2045,19 @@ public class ConsentManagerImpl implements ConsentManager {
     }
 
     /**
-     * Checks whether the given PII principal ID refers to the same user as the other username, honouring the
-     * case-sensitivity configuration of the PII principal's userstore.
+     * Checks whether the given user ID refers to the same user as the other username, honouring the
+     * case-sensitivity configuration of the userstore.
      *
-     * @param piiPrincipalId PII principal ID to check.
-     * @param otherUserId    Other username to compare against.
+     * @param userId      User ID to check.
+     * @param otherUserId Other username to compare against.
      * @return true if both refer to the same user.
      * @throws ConsentManagementException if the userstore case-sensitivity cannot be resolved.
      */
-    private boolean isSamePrincipal(String piiPrincipalId, String otherUserId) throws ConsentManagementException {
+    private boolean isSameUser(String userId, String otherUserId) throws ConsentManagementException {
 
-        return isUserNameCaseSensitive(piiPrincipalId)
-                ? StringUtils.equals(piiPrincipalId, otherUserId)
-                : StringUtils.equalsIgnoreCase(getLowerCaseUserName(piiPrincipalId), otherUserId);
+        return isUserNameCaseSensitive(userId)
+                ? StringUtils.equals(userId, otherUserId)
+                : StringUtils.equalsIgnoreCase(userId, otherUserId);
     }
 
     /**

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/InterceptingConsentManager.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/InterceptingConsentManager.java
@@ -261,6 +261,30 @@ public class InterceptingConsentManager extends PrivilegedConsentManagerImpl {
     }
 
     /**
+     * Get a consent receipt (V2 extended schema) after validating it belongs to the accessing tenant and to the
+     * given PII principal.
+     *
+     * @param receiptId      Consent receipt ID.
+     * @param piiPrincipalId PII principal ID expected to own the receipt.
+     * @return Receipt if it belongs to the accessing tenant and the given PII principal.
+     * @throws ConsentManagementException if the receipt belongs to a different tenant or PII principal.
+     */
+    @Override
+    public Receipt getReceiptWithExtendedSchema(String receiptId, String piiPrincipalId)
+            throws ConsentManagementException {
+
+        Receipt receipt = super.getReceiptWithExtendedSchema(receiptId, piiPrincipalId);
+
+        if (isCrossTenantOperation(ConsentUtils.getTenantDomainFromCarbonContext(), receipt.getTenantDomain())) {
+            String message = String.format(ERROR_CODE_RECEIPT_ID_INVALID.getMessage(), receiptId) + " in tenant: " +
+                    ConsentUtils.getTenantDomainFromCarbonContext();
+            throw new ConsentManagementClientException(message, ERROR_CODE_RECEIPT_ID_INVALID.getCode());
+        }
+
+        return receipt;
+    }
+
+    /**
      * Delete Purpose (UUID) after validating the tenant domain of the Purpose.
      *
      * @param uuid Purpose UUID.

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -875,6 +875,13 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
         return consentManager.getReceiptWithExtendedSchema(receiptId);
     }
 
+    @Override
+    public Receipt getReceiptWithExtendedSchema(String receiptId, String piiPrincipalId)
+            throws ConsentManagementException {
+
+        return consentManager.getReceiptWithExtendedSchema(receiptId, piiPrincipalId);
+    }
+
     public List<ReceiptListResponse> searchReceipts(int limit, int offset, String piiPrincipalId, String spTenantDomain,
                                                     String service, String state) throws ConsentManagementException {
 
@@ -1354,6 +1361,13 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
             throws ConsentManagementException {
 
         return consentManager.getConsentAuthorizations(consentId);
+    }
+
+    @Override
+    public List<ConsentAuthorization> getConsentAuthorizations(String consentId, String piiPrincipalId)
+            throws ConsentManagementException {
+
+        return consentManager.getConsentAuthorizations(consentId, piiPrincipalId);
     }
 
     @Override

--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/PrivilegedConsentManagerImpl.java
@@ -1364,10 +1364,10 @@ public class PrivilegedConsentManagerImpl implements PrivilegedConsentManager {
     }
 
     @Override
-    public List<ConsentAuthorization> getConsentAuthorizations(String consentId, String piiPrincipalId)
+    public List<ConsentAuthorization> getConsentAuthorizations(String consentId, String userId)
             throws ConsentManagementException {
 
-        return consentManager.getConsentAuthorizations(consentId, piiPrincipalId);
+        return consentManager.getConsentAuthorizations(consentId, userId);
     }
 
     @Override

--- a/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImplTest.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/ConsentManagerImplTest.java
@@ -304,6 +304,109 @@ public class ConsentManagerImplTest {
         }
     }
 
+    @Test
+    public void testGetReceiptWithExtendedSchema_owner_succeeds() throws Exception {
+
+        setupUserStoreManagerMock(false);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithoutAuthorizations("subject1");
+
+        Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId, "subject1");
+
+        Assert.assertEquals(receipt.getConsentReceiptId(), consentId);
+    }
+
+    @Test
+    public void testGetReceiptWithExtendedSchema_ownerDifferentCase_caseInsensitiveUserstore_succeeds()
+            throws Exception {
+
+        setupUserStoreManagerMock(false);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithoutAuthorizations("subject1");
+
+        Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId, "SUBJECT1");
+
+        Assert.assertEquals(receipt.getConsentReceiptId(), consentId);
+    }
+
+    @Test(expectedExceptions = ConsentManagementClientException.class)
+    public void testGetReceiptWithExtendedSchema_ownerDifferentCase_caseSensitiveUserstore_throws()
+            throws Exception {
+
+        setupUserStoreManagerMock(true);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithoutAuthorizations("subject1");
+
+        consentManager.getReceiptWithExtendedSchema(consentId, "SUBJECT1");
+    }
+
+    @Test(expectedExceptions = ConsentManagementClientException.class)
+    public void testGetReceiptWithExtendedSchema_differentUser_throws() throws Exception {
+
+        setupUserStoreManagerMock(false);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithoutAuthorizations("subject1");
+
+        consentManager.getReceiptWithExtendedSchema(consentId, "someoneElse");
+    }
+
+    @Test
+    public void testGetConsentAuthorizations_owner_succeeds() throws Exception {
+
+        setupUserStoreManagerMock(false);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithAuthorizations("subject1", "approver1");
+
+        List<ConsentAuthorization> authorizations = consentManager.getConsentAuthorizations(consentId, "subject1");
+
+        Assert.assertEquals(authorizations.size(), 1);
+    }
+
+    @Test
+    public void testGetConsentAuthorizations_delegatedAuthorizer_succeeds() throws Exception {
+
+        setupUserStoreManagerMock(false);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithAuthorizations("subject1", "approver1");
+
+        List<ConsentAuthorization> authorizations = consentManager.getConsentAuthorizations(consentId, "approver1");
+
+        Assert.assertEquals(authorizations.size(), 1);
+    }
+
+    @Test
+    public void testGetConsentAuthorizations_ownerDifferentCase_caseInsensitiveUserstore_succeeds()
+            throws Exception {
+
+        setupUserStoreManagerMock(false);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithAuthorizations("subject1", "approver1");
+
+        List<ConsentAuthorization> authorizations = consentManager.getConsentAuthorizations(consentId, "SUBJECT1");
+
+        Assert.assertEquals(authorizations.size(), 1);
+    }
+
+    @Test(expectedExceptions = ConsentManagementClientException.class)
+    public void testGetConsentAuthorizations_ownerDifferentCase_caseSensitiveUserstore_throws() throws Exception {
+
+        setupUserStoreManagerMock(true);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithAuthorizations("subject1", "approver1");
+
+        consentManager.getConsentAuthorizations(consentId, "SUBJECT1");
+    }
+
+    @Test(expectedExceptions = ConsentManagementClientException.class)
+    public void testGetConsentAuthorizations_unauthorizedUser_throws() throws Exception {
+
+        setupUserStoreManagerMock(false);
+        consentManager = new ConsentManagerImpl(configurationHolder);
+        String consentId = createConsentWithAuthorizations("subject1", "approver1");
+
+        consentManager.getConsentAuthorizations(consentId, "stranger");
+    }
+
     private void setupUserStoreManagerMock(boolean isUserNameCaseSensitive) throws Exception {
 
         RealmService realmService = configurationHolder.getRealmService();

--- a/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/InterceptingConsentManagerTest.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/test/java/org/wso2/carbon/consent/mgt/core/InterceptingConsentManagerTest.java
@@ -875,6 +875,48 @@ public class InterceptingConsentManagerTest {
         Assert.assertEquals(receipt.getState(), REVOKE_STATE);
     }
 
+    @Test
+    public void testGetReceiptWithExtendedSchemaOwnerCheck() throws Exception {
+
+        String consentId = addV2ReceiptDirectly("subject1", SUPER_TENANT_ID, SUPER_TENANT_DOMAIN_NAME);
+
+        Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId, "subject1");
+
+        Assert.assertEquals(receipt.getConsentReceiptId(), consentId);
+    }
+
+    @Test(expectedExceptions = ConsentManagementClientException.class)
+    public void testGetReceiptWithExtendedSchemaOwnerCheck_differentUser_throws() throws Exception {
+
+        String consentId = addV2ReceiptDirectly("subject1", SUPER_TENANT_ID, SUPER_TENANT_DOMAIN_NAME);
+
+        consentManager.getReceiptWithExtendedSchema(consentId, "someoneElse");
+        Assert.assertTrue(false, "Expected: " + ConsentManagementClientException.class.getName());
+    }
+
+    private String addV2ReceiptDirectly(String piiPrincipalId, int tenantId, String tenantDomain) throws Exception {
+
+        String consentId = java.util.UUID.randomUUID().toString();
+        ReceiptInput receiptInput = new ReceiptInput();
+        receiptInput.setConsentReceiptId(consentId);
+        receiptInput.setPiiPrincipalId(piiPrincipalId);
+        receiptInput.setTenantId(tenantId);
+        receiptInput.setTenantDomain(tenantDomain);
+        receiptInput.setState(org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ACTIVE_STATE);
+        receiptInput.setCollectionMethod("V2");
+        receiptInput.setLanguage("EN");
+        receiptInput.setVersion("KI-CR-v1.1.0");
+        receiptInput.setJurisdiction("LK");
+        receiptInput.setPolicyUrl("http://test.com/policy");
+        receiptInput.setPiiControllerInfo("{\"piiController\":\"test\",\"contact\":\"test\",\"Address\":"
+                + "{\"addressCountry\":\"LK\",\"addressLocality\":\"Colombo\",\"addressRegion\":\"WP\","
+                + "\"postOfficeBoxNumber\":\"\",\"postalCode\":\"10000\",\"streetAddress\":\"Test\"},"
+                + "\"email\":\"test@test.com\",\"phone\":\"+94\",\"onBehalf\":false,\"piiControllerUrl\":\"http://test.com\"}");
+        receiptInput.setServices(Collections.emptyList());
+        new ReceiptDAOImpl().addReceiptWithAuthorizations(receiptInput, Collections.emptyList());
+        return consentId;
+    }
+
     private List<AddReceiptResponse> addReceipt(String... principleIDs) throws ConsentManagementException {
 
         PIICategory piiCategory = addPIICategory("PII1");


### PR DESCRIPTION
This pull request introduces new authorization checks and API extensions to the consent management core, ensuring that only authorized users (owners or delegated authorizers) can access consent receipts and their authorizations. It also adds comprehensive test coverage for these new behaviors.

**Key changes:**

### Authorization and Access Control Enhancements

* Added overloaded methods `getConsentAuthorizations(String consentId, String piiPrincipalId)` and `getReceiptWithExtendedSchema(String receiptId, String piiPrincipalId)` to `ConsentManager`, which validate that the requesting PII principal is either the owner or an authorized user before returning sensitive data. Default implementations fall back to the original methods for backward compatibility.
* Implemented these authorization checks in `ConsentManagerImpl`, throwing a `ConsentManagementClientException` if the user is unauthorized. The logic checks for ownership, delegated authorization, and handles userstore case sensitivity. 
* Extended `InterceptingConsentManager` and `PrivilegedConsentManagerImpl` to support the new methods, ensuring tenant and user checks are enforced in all layers.

### Testing

* Added extensive unit tests to `ConsentManagerImplTest` and `InterceptingConsentManagerTest` to verify correct authorization behavior for both owners and delegated authorizers, as well as to ensure proper handling of case sensitivity in userstores. Tests also confirm that unauthorized access is correctly rejected.

These changes improve the security and robustness of consent data access by ensuring only authorized principals can retrieve sensitive consent information.