### PR TITLE
Fix 500 error on invalid pagination cursor token

### DIFF
--- a/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/util/FilterQueriesUtil.java
+++ b/components/org.wso2.carbon.consent.mgt.core/src/main/java/org/wso2/carbon/consent/mgt/core/util/FilterQueriesUtil.java
@@ -31,6 +31,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_CURSOR_TOKEN;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_FILTER_EXPRESSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.FilterConstants;
@@ -91,7 +92,7 @@ public class FilterQueriesUtil {
             ExpressionNode node = new ExpressionNode();
             node.setAttributeValue(FilterConstants.FILTER_ATTR_AFTER);
             node.setOperation(OP_GT);
-            node.setValue(new String(Base64.getDecoder().decode(after), StandardCharsets.UTF_8));
+            node.setValue(decodeCursor(after));
             nodes.add(node);
         }
 
@@ -99,11 +100,22 @@ public class FilterQueriesUtil {
             ExpressionNode node = new ExpressionNode();
             node.setAttributeValue(FilterConstants.FILTER_ATTR_BEFORE);
             node.setOperation(OP_LT);
-            node.setValue(new String(Base64.getDecoder().decode(before), StandardCharsets.UTF_8));
+            node.setValue(decodeCursor(before));
             nodes.add(node);
         }
 
         return nodes;
+    }
+
+    private static String decodeCursor(String cursor) throws ConsentManagementClientException {
+
+        try {
+            return new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new ConsentManagementClientException(
+                    String.format(ERROR_CODE_INVALID_CURSOR_TOKEN.getMessage(), cursor),
+                    ERROR_CODE_INVALID_CURSOR_TOKEN.getCode());
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- The consents list endpoint (`GET /consent-mgt/consents`) decodes the `after`/`before` pagination cursor query params as Base64 without validating the input first.
- An invalid value (e.g. `after=1`) causes `Base64.getDecoder().decode()` to throw an uncaught `IllegalArgumentException`, which surfaces as a 500 Internal Server Error instead of a 400 Bad Request.
- This PR wraps the decode call in `FilterQueriesUtil.getExpressionNodes` and converts the failure into a `ConsentManagementClientException` using the existing `ERROR_CODE_INVALID_CURSOR_TOKEN` (`CM_00123`) error code, so callers get a proper 400 response.

Fixes https://github.com/wso2/product-is/issues/28223

## Test plan
- [x] Built the module (`mvn compile`) to confirm the change compiles cleanly.
- [ ] Manually verify: `GET /consents?after=1` now returns 400 with `CM_00123` instead of 500.
- [ ] Manually verify: a valid Base64 `after`/`before` cursor still paginates correctly.